### PR TITLE
WIP: Fix incorrect API URI's

### DIFF
--- a/psef/v1/files.py
+++ b/psef/v1/files.py
@@ -23,12 +23,12 @@ from psef.helpers import (
 from . import api
 
 
-@api.route("/files/", methods=['POST'])
+@api.route("/file", methods=['POST'])
 @auth.login_required
 def post_file() -> JSONResponse[str]:
     """Temporarily store some data on the server.
 
-    .. :quickref: File; Safe a file temporarily on the server.
+    .. :quickref: File; Save a file temporarily on the server.
 
     .. note::
         The posted data will be removed after 60 seconds.

--- a/psef/v1/snippets.py
+++ b/psef/v1/snippets.py
@@ -11,8 +11,8 @@ import psef.auth as auth
 import psef.models as models
 import psef.helpers as helpers
 from psef import current_user
-from psef.models import db
 from psef.errors import APICodes, APIException
+from psef.models import db
 from psef.helpers import (
     JSONType, JSONResponse, EmptyResponse, jsonify, ensure_json_dict,
     ensure_keys_in_dict, make_empty_response
@@ -21,7 +21,7 @@ from psef.helpers import (
 from . import api
 
 
-@api.route('/snippet', methods=['PUT'])
+@api.route('/snippets/', methods=['PUT'])
 @auth.permission_required('can_use_snippets')
 def add_snippet() -> JSONResponse[models.Snippet]:
     """Add or modify a :class:`.models.Snippet` by key.

--- a/psef/v1/submissions.py
+++ b/psef/v1/submissions.py
@@ -309,7 +309,7 @@ def unselect_rubric_item(
 
 @api.route(
     "/submissions/<int:submission_id>/rubricitems/<int:rubricitem_id>",
-    methods=['PATCH']
+    methods=['POST']
 )
 @helpers.feature_required('RUBRICS')
 @helpers.feature_required('INCREMENTAL_RUBRIC_SUBMISSION')
@@ -484,15 +484,17 @@ def get_grade_history(submission_id: int
     return jsonify(hist)
 
 
-@api.route("/submissions/<int:submission_id>/files/", methods=['POST'])
+@api.route("/submissions/<int:submission_id>/file", methods=['POST'])
 def create_new_file(submission_id: int) -> JSONResponse[t.Mapping[str, t.Any]]:
     """Create a new file or directory for the given submission.
 
     .. :quickref: Submission; Create a new file or directory for a submission.
 
-    :param str path: The path of the new file to create. If the path ends in
+    :qparam str path: The path of the new file to create. If the path ends in
         a forward slash a new directory is created and the body of the request
         is ignored, otherwise a regular file is created.
+    :param int submission_id: The id of the submission the file should be
+        created in.
 
     :returns: Stat information about the new file, see
         :py:func:`.files.get_stat_information`

--- a/psef_test/test_code.py
+++ b/psef_test/test_code.py
@@ -747,7 +747,7 @@ def test_rename_code(
     def create_file(path):
         return test_client.req(
             'post',
-            f'/api/v1/submissions/{work_id}/files/?path={path}',
+            f'/api/v1/submissions/{work_id}/file?path={path}',
             200,
         )['id']
 

--- a/psef_test/test_course.py
+++ b/psef_test/test_course.py
@@ -145,7 +145,7 @@ def test_add_course(
 
         course = test_client.req(
             'post',
-            f'/api/v1/courses/',
+            f'/api/v1/course',
             error or 200,
             data=data,
             result=error_template if error else {
@@ -305,8 +305,8 @@ def test_add_user_to_course(
             data['role_id'] = role.id
 
         res = test_client.req(
-            'put',
-            f'/api/v1/courses/{course.id}/users/',
+            'post',
+            f'/api/v1/courses/{course.id}/user',
             error or 201,
             data=data,
             result=error_template if error else {
@@ -343,17 +343,13 @@ def test_add_user_to_course(
         data_error(error=403)('thomas_schaper@example.com'),
         ('stupid1@example.com'),
         ('admin@example.com'),
-        data_error(error=404)(-1),
-        data_error(error=400)(True),
-        data_error(error=400)(None),
     ]
 )
 @pytest.mark.parametrize('role_n', ['Student', 'Teacher'])
 @pytest.mark.parametrize('include_role', [True, missing_error(False)])
-@pytest.mark.parametrize('include_user_id', [True, missing_error(False)])
 def test_update_user_in_course(
     logged_in, named_user, test_client, request, session, course_n, role_n,
-    include_user_id, include_role, error_template, to_update
+    include_role, error_template, to_update
 ):
     perm_err = request.node.get_marker('perm_error')
     data_err = request.node.get_marker('data_error')
@@ -379,14 +375,12 @@ def test_update_user_in_course(
 
     with logged_in(named_user):
         data = {}
-        if include_user_id:
-            data['user_id'] = user_id
         if include_role:
             data['role_id'] = role.id
 
         test_client.req(
-            'put',
-            f'/api/v1/courses/{course.id}/users/',
+            'patch',
+            f'/api/v1/courses/{course.id}/users/{user_id}',
             error or 204,
             result=error_template if error else None,
             data=data,
@@ -494,7 +488,7 @@ def test_add_courseroles(
             data['name'] = role_name
         test_client.req(
             'post',
-            f'/api/v1/courses/{course.id}/roles/',
+            f'/api/v1/courses/{course.id}/role',
             error or 204,
             data=data,
             result=error_template if error else None
@@ -698,7 +692,7 @@ def test_delete_lti_courseroles(
     with logged_in(ta_user):
         test_client.req(
             'post',
-            f'/api/v1/courses/{course.id}/roles/',
+            f'/api/v1/courses/{course.id}/role',
             204,
             data={'name': 'NEW_ROLE'},
         )
@@ -760,9 +754,9 @@ def test_add_assignment(
         if name is not None:
             data['name'] = name
 
-        assig = test_client.req(
+        test_client.req(
             'post',
-            f'/api/v1/courses/{course.id}/assignments/',
+            f'/api/v1/courses/{course.id}/assignment',
             error or 200,
             data=data,
             result=error_template if error else {

--- a/psef_test/test_files.py
+++ b/psef_test/test_files.py
@@ -30,7 +30,7 @@ def test_get_code_metadata(
     with logged_in(named_user):
         res = test_client.req(
             'post',
-            '/api/v1/files/',
+            '/api/v1/file',
             error or 201,
             real_data=filestr,
             result=error_template if error else str,

--- a/psef_test/test_lti.py
+++ b/psef_test/test_lti.py
@@ -461,7 +461,7 @@ def test_lti_assignment_create(
         course = assig['course']
         test_client.req(
             'post',
-            f'/api/v1/courses/{course["id"]}/assignments/',
+            f'/api/v1/courses/{course["id"]}/assignment',
             400,
             data={
                 'name': 'wow',

--- a/psef_test/test_snippets.py
+++ b/psef_test/test_snippets.py
@@ -38,7 +38,7 @@ def test_simple_add_delete(
             snips.append(snip)
             test_client.req(
                 'put',
-                '/api/v1/snippet',
+                '/api/v1/snippets/',
                 error or 201,
                 data=snip,
                 result=error_template if error else {
@@ -87,7 +87,7 @@ def test_simple_update(
             snips.append(snip)
             test_client.req(
                 'put',
-                '/api/v1/snippet',
+                '/api/v1/snippets/',
                 error or 201,
                 data=snip,
                 result=error_template if error else {
@@ -107,7 +107,7 @@ def test_simple_update(
             snips[0]['value'] = 'dag dag'
             test_client.req(
                 'put',
-                '/api/v1/snippet',
+                '/api/v1/snippets/',
                 201,
                 data={
                     'value': snips[0]['value'],
@@ -143,7 +143,7 @@ def test_full_update(named_user, logged_in, test_client):
             snips.append(snip)
             test_client.req(
                 'put',
-                '/api/v1/snippet',
+                '/api/v1/snippets/',
                 201,
                 data=snip,
                 result={
@@ -183,7 +183,7 @@ def test_modify_others_snippet(named_user, ta_user, test_client, logged_in):
         snip = {'key': 'k', 'value': 'v'}
         snip = test_client.req(
             'put',
-            '/api/v1/snippet',
+            '/api/v1/snippets/',
             201,
             data=snip,
             result={

--- a/psef_test/test_submissions.py
+++ b/psef_test/test_submissions.py
@@ -840,9 +840,9 @@ def test_get_zip_file(
 ):
     assignment, work = assignment_real_works
     if get_own:
-        work_id = m.Work.query.filter_by(
-            user=named_user
-        ).order_by(m.Work.created_at.desc()).first().id
+        work_id = m.Work.query.filter_by(user=named_user).order_by(
+            m.Work.created_at.desc()
+        ).first().id
     else:
         work_id = work['id']
 
@@ -962,11 +962,9 @@ def test_get_teacher_zip_file(
 
     m.Assignment.query.filter_by(
         id=m.Work.query.get(work_id).assignment_id,
-    ).update(
-        {
-            'state': m._AssignmentStateEnum.done,
-        },
-    )
+    ).update({
+        'state': m._AssignmentStateEnum.done,
+    }, )
 
     assert get_files(student_user, False) == set(
         [
@@ -1057,14 +1055,18 @@ def test_add_file(
             f'/api/v1/submissions/{work_id}/file',
             404,
             result=error_template,
-            query={'path': '/non/existing/'}
+            query={
+                'path': '/non/existing/'
+            }
         )
         test_client.req(
             'post',
             f'/api/v1/submissions/{work_id}/file',
             400,
             result=error_template,
-            query={'path': '/too_short/'}
+            query={
+                'path': '/too_short/'
+            }
         )
 
         res = test_client.req(
@@ -1137,9 +1139,9 @@ def test_add_file(
             real_data='TEAER_FILE',
         )
 
-        session.query(m.Assignment).filter_by(
-            id=m.Work.query.get(work_id).assignment_id
-        ).update(
+        session.query(
+            m.Assignment
+        ).filter_by(id=m.Work.query.get(work_id).assignment_id).update(
             {
                 'deadline':
                     datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -1177,9 +1179,9 @@ def test_add_file(
         )
 
     with logged_in(ta_user):
-        session.query(m.Assignment).filter_by(
-            id=m.Work.query.get(work_id).assignment_id
-        ).update(
+        session.query(
+            m.Assignment
+        ).filter_by(id=m.Work.query.get(work_id).assignment_id).update(
             {
                 'deadline':
                     datetime.datetime.utcnow() + datetime.timedelta(days=1)
@@ -1316,9 +1318,9 @@ def test_add_file(
             }
         )
 
-        session.query(m.Assignment).filter_by(
-            id=m.Work.query.get(work_id).assignment_id
-        ).update(
+        session.query(
+            m.Assignment
+        ).filter_by(id=m.Work.query.get(work_id).assignment_id).update(
             {
                 'deadline':
                     datetime.datetime.utcnow() + datetime.timedelta(days=1)
@@ -1330,8 +1332,8 @@ def test_add_file(
     'filename', ['../test_submissions/single_dir_archive.zip'], indirect=True
 )
 @pytest.mark.parametrize(
-    'named_user', ['Thomas Schaper',
-                   http_error(error=403)('Stupid1')],
+    'named_user',
+    ['Thomas Schaper', http_error(error=403)('Stupid1')],
     indirect=True
 )
 @pytest.mark.parametrize('graders', [(['Thomas Schaper', 'Devin Hillenius'])])
@@ -1358,8 +1360,10 @@ def test_change_grader(
                 'patch',
                 f'/api/v1/assignments/{assignment.id}/divide',
                 204,
-                data={'graders': {g: 1
-                                  for g in grader_ids}}
+                data={
+                    'graders': {g: 1
+                                for g in grader_ids}
+                }
             )
             submission = test_client.req(
                 'get', f'/api/v1/assignments/{assignment.id}/submissions/', 200
@@ -1373,7 +1377,9 @@ def test_change_grader(
                 f'/api/v1/submissions/{submission["id"]}/grader',
                 404,
                 result=error_template,
-                data={'user_id': 100000}
+                data={
+                    'user_id': 100000
+                }
             )
             with logged_in(ta_user):
                 submission = test_client.req(
@@ -1388,7 +1394,9 @@ def test_change_grader(
                 f'/api/v1/submissions/{submission["id"]}/grader',
                 400,
                 result=error_template,
-                data={'user_id': stupid1_id}
+                data={
+                    'user_id': stupid1_id
+                }
             )
             with logged_in(ta_user):
                 submission = test_client.req(
@@ -1405,7 +1413,9 @@ def test_change_grader(
             f'/api/v1/submissions/{submission["id"]}/grader',
             code,
             result=res,
-            data={'user_id': new_grader_id}
+            data={
+                'user_id': new_grader_id
+            }
         )
         with logged_in(ta_user):
             submission = test_client.req(


### PR DESCRIPTION
## Description
The following routes were incorrect:
- `POST /courses/<course_id>/roles/ -> POST /courses/<c_id>role`
  It creates a single resource.

-
```
                             |-> PATCH /courses/<c_id>/users/<user_id>
  PUT /courses/<c_id>/users -|
                             |-> POST /courses/<c_id>/user
```
  It created or updated the role of a user. However different payloads where
  required for updating or adding so this should not have been a single route.
  This also makes the function easier to manage.
- `POST /courses/<c_id>/assignments/ -> POST /courses/<c_id>/assignment`
  It creates a single resource.
- `POST /courses/ -> POST /course`
  It creates a single resource.
- `POST /files/ -> POST /file`
  It creates a single resource.
- `PUT /snippet -> PUT /snippets/`
  It updates a single item however a plural form should be used here as this is
  stated in the documentation.
- `PATCH /submissions/<int:s_id>/rubricitems/<int:ri_id> -> POST /submissions/<int:s_id>/rubricitems/<int:ri_id>`
  It always creates a new connection, it does not alter the rubricitem. I think
  this is better this way but this needs discussion.
- `POST /submissions/<int:submission_id>/files/ -> POST /submissions/<int:submission_id>/file`
  It creates a single resource.

The work on the backend is done, things still left:
- [ ] Fix frontend api calls.
- [ ] Fix filesystem api calls, best would be with a versioning check.