### PR TITLE
Add a `with_items_in_request` decorator to check required fields

### DIFF
--- a/psef/models.py
+++ b/psef/models.py
@@ -9,6 +9,7 @@ import enum
 import math
 import uuid
 import typing as t
+import numbers
 import datetime
 from random import shuffle
 from itertools import cycle
@@ -1092,7 +1093,11 @@ class Work(Base):
             return between(0, selected / max_points * 10, 10)
         return self._grade
 
-    def set_grade(self, new_grade: float, user: User) -> None:
+    def set_grade(
+        self,
+        new_grade: t.Optional[t.Union[numbers.Real, float]],
+        user: User,
+    ) -> None:
         """Set the grade to the new grade.
 
         .. note:: This also passes back the grade to LTI if this is necessary
@@ -1102,7 +1107,7 @@ class Work(Base):
         :param user: The user setting the new grade.
         :returns: Nothing
         """
-        self._grade = new_grade
+        self._grade = None if new_grade is None else float(new_grade)
         passback = self.assignment.should_passback
         grade = self.grade
         history = GradeHistory(

--- a/psef_test/test_linting.py
+++ b/psef_test/test_linting.py
@@ -112,7 +112,7 @@ def test_linters(
     get_work = request.node.get_marker('get_works')
     perm_err = request.node.get_marker('perm_error')
     set_perm_err = (not use_ta) and perm_err
-    if set_perm_err:
+    if set_perm_err and not run_err.get('error'):
         run_err['error'] = set_perm_err.kwargs['error']
 
     with logged_in(ta_user if use_ta else named_user):
@@ -185,7 +185,7 @@ def test_linters(
         linter_result = test_client.req(
             'get',
             f'/api/v1/assignments/{assig_id}/linters/',
-            code if set_perm_err else 200,
+            perm_err.kwargs.get('error') if set_perm_err else 200,
             result=error_template if set_perm_err else result,
         )
 

--- a/psef_test/test_submissions.py
+++ b/psef_test/test_submissions.py
@@ -11,6 +11,7 @@ import psef.models as m
 http_error = pytest.mark.http_error
 perm_error = pytest.mark.perm_error
 data_error = pytest.mark.data_error
+late_data_error = pytest.mark.late_data_error
 
 
 @pytest.mark.parametrize('filename', ['test_flake8.tar.gz'], indirect=True)
@@ -132,8 +133,8 @@ def test_get_grade_history(
 )
 @pytest.mark.parametrize(
     'grade', [
-        data_error(-1),
-        data_error(11),
+        late_data_error(-1),
+        late_data_error(11),
         data_error('err'),
         None,
         4,
@@ -157,9 +158,12 @@ def test_patch_submission(
 
     perm_err = request.node.get_marker('perm_error')
     data_err = request.node.get_marker('data_error')
-    if perm_err:
+    late_data_err = request.node.get_marker('late_data_error')
+    if data_err:
+        error = 400
+    elif perm_err:
         error = perm_err.kwargs['error']
-    elif data_err:
+    elif late_data_err:
         error = 400
     else:
         error = False


### PR DESCRIPTION
## Description
This has a few advantages over just using `ensure_keys_in_dict`. The first is
that this decorator ensures you have the required arguments in your function
declaration with the correct types. So casting is not necessary anymore and the
'casts' (they are not gone, just implicit) are checked during read time (if you
had such a thing in python). The second advantage is that as the required
objects are static (they are evaluated once, during read time), they can be
inspected more easily, it is also easier too see what different endpoints
require. This brings the third point: the documentation for request objects can
now be generated automatically or at least be checked that way (make sure every
key is described). We could even start generating a json schema from our source
code.

This PR is a proposal, so lets discuss! Please note that not all code has been
refactored as we might not even want to keep this new approach.
