### PR TITLE
Fix sidebar shadow with more than one submenu level

### DIFF
--- a/src/components/Sidebar/index.vue
+++ b/src/components/Sidebar/index.vue
@@ -635,7 +635,7 @@ export default {
             color: @color-primary;
         }
 
-        &:first-child {
+        &:last-child {
             box-shadow: 0 0 10px rgba(0, 0, 0, .75);
         }
 


### PR DESCRIPTION
#451 introduced a bug that the sidebar didn't drop a shadow on the page when more than one submenu level was open.