### PR TITLE
Release hotfix JungleJoy.1.2

### DIFF
--- a/psef/auto_test/__init__.py
+++ b/psef/auto_test/__init__.py
@@ -1239,13 +1239,22 @@ class AutoTestRunner:
         self.fixtures = self.instructions['fixtures']
         self._reqs: t.Dict[t.Tuple[int, int], requests.Session] = {}
 
+    @staticmethod
+    def _get_amount_of_needed_workers() -> int:
+        """Get the amount of needed workers.
+
+        >>> AutoTestRunner._get_amount_of_needed_workers() >= 4
+        True
+        """
+        return _get_amount_cpus() + 4
+
     def _make_worker_pool(
         self, base_container_name: str, cpu_cores: CpuCores
     ) -> cg_worker_pool.WorkerPool:
         mult = 1 if self.instructions.get('is_continuous_run', False) else 0
         return cg_worker_pool.WorkerPool(
             # Over provision a bit so clones can be made quicker.
-            processes=_get_amount_cpus() + 4,
+            processes=self._get_amount_of_needed_workers(),
             function=lambda work:
             _run_student(self, base_container_name, cpu_cores, work.result_id),
             sleep_time=mult * self.config['AUTO_TEST_CF_SLEEP_TIME'],

--- a/psef_test/test_auto_test.py
+++ b/psef_test/test_auto_test.py
@@ -56,6 +56,10 @@ def monkeypatch_for_run(monkeypatch, lxc_stub, stub_function_class):
         )
     )
     monkeypatch.setattr(
+        psef.auto_test.AutoTestRunner, '_get_amount_of_needed_workers',
+        stub_function_class(lambda: 1)
+    )
+    monkeypatch.setattr(
         psef.tasks, 'check_heartbeat_auto_test_run', stub_function_class()
     )
     monkeypatch.setattr(
@@ -548,7 +552,6 @@ def test_run_auto_test(
                 data={'state': 'open'}
             )
         url = f'/api/v1/auto_tests/{test["id"]}'
-        live_server_url = live_server()
 
         _run_student = psef.auto_test._run_student
 
@@ -609,6 +612,7 @@ def test_run_auto_test(
             session.commit()
         run = t.test_run
 
+        live_server_url = live_server()
         psef.auto_test.start_polling(app.config, repeat=False)
 
         with logged_in(teacher, yield_token=True) as token:

--- a/src/components/AssignmentState.vue
+++ b/src/components/AssignmentState.vue
@@ -9,9 +9,9 @@
                        :submit="() => updateState(states.OPEN)"
                        @success="afterUpdateState"
                        :duration="0"
-                       confirm="Students will not be able to see their grade.
+                       :confirm="`Students will not be able to see their grade.
                        whether they can see the assignment at all is determined
-                       by the assignment's state in ${lmsName}.">
+                       by the assignment's state in ${lmsName}.`">
             <icon :name="icons[states.HIDDEN]"/>
             <icon :name="icons[states.OPEN]"/>
         </submit-button>

--- a/src/components/AutoTest.vue
+++ b/src/components/AutoTest.vue
@@ -374,7 +374,8 @@
                                    :assignment="assignment"
                                    :editable="configEditable"
                                    :result="result"
-                                   :other-suites="allNonDeletedSuites" />
+                                   :other-suites="allNonDeletedSuites"
+                                   :is-continuous="currentRun && currentRun.isContinuous" />
                     <p class="text-muted font-italic mb-3"
                        key="no-sets"
                        v-if="test.sets.filter(s => !s.deleted).length === 0">
@@ -611,11 +612,10 @@ export default {
             return this.storeCreateAutoTestRun({
                 autoTestId: this.autoTestId,
                 continuousFeedback,
-            });
+            }).then(() => this.storeForceLoadSubmissions(this.assignmentId));
         },
 
         afterRunAutoTest() {
-            this.storeForceLoadSubmissions(this.assignmentId);
             this.configCollapsed = true;
             this.pollingTimer = setTimeout(this.loadAutoTestRun, this.pollingInterval);
         },
@@ -651,8 +651,7 @@ export default {
                         switch (this.$utils.getProps(err, null, 'response', 'status')) {
                             case 403:
                                 this.message = {
-                                    message:
-                                        'You do not have permission to view the autotest before the deadline',
+                                    text: 'The AutoTest results are not yet available.',
                                     isError: false,
                                 };
                                 break;

--- a/src/components/AutoTestSet.vue
+++ b/src/components/AutoTestSet.vue
@@ -35,6 +35,7 @@
                              :other-suites="otherSuites"
                              :value="value.suites[j]"
                              :result="result"
+                             :is-continuous="isContinuous"
                              @input="updateSuite(j, $event)" />
         </masonry>
 
@@ -120,25 +121,25 @@ export default {
             type: Object,
             required: true,
         },
-
         assignment: {
             type: Object,
             required: true,
         },
-
         editable: {
             type: Boolean,
             default: false,
         },
-
         result: {
             type: Object,
             default: null,
         },
-
         otherSuites: {
             type: Array,
             required: true,
+        },
+        isContinuous: {
+            type: Boolean,
+            default: false,
         },
     },
 

--- a/src/components/AutoTestStep.vue
+++ b/src/components/AutoTestStep.vue
@@ -728,6 +728,7 @@ import 'vue-awesome/icons/chevron-down';
 import 'vue-awesome/icons/clock-o';
 import 'vue-awesome/icons/ban';
 
+import * as assignmentStates from '@/store/assignment-states';
 import { visualizeWhitespace } from '@/utils/visualize';
 
 import Collapse from './Collapse';
@@ -767,6 +768,10 @@ export default {
         result: {
             type: Object,
             default: null,
+        },
+        isContinuous: {
+            type: Boolean,
+            default: false,
         },
     },
 
@@ -969,13 +974,14 @@ export default {
         },
 
         canViewOutput() {
-            if (
-                !this.result ||
-                this.stepResult.state === 'hidden' ||
-                !this.canViewDetails ||
-                (this.assignment.state !== 'done' &&
-                    !this.permissions.can_view_autotest_before_done)
-            ) {
+            const result = this.result && this.stepResult.state !== 'hidden';
+            const canViewDetails = this.canViewDetails;
+            const canViewFeedback =
+                this.isContinuous ||
+                this.assignment.state === assignmentStates.DONE ||
+                this.permissions.can_view_autotest_before_done;
+
+            if (!result || !canViewDetails || !canViewFeedback) {
                 return false;
             }
 
@@ -1083,16 +1089,8 @@ export default {
         },
 
         canViewSubStepOutput(i) {
-            if (
-                !this.result ||
-                !this.canViewDetails ||
-                (this.assignment.state !== 'done' &&
-                    !this.permissions.can_view_autotest_before_done)
-            ) {
-                return false;
-            }
-
             return (
+                this.canViewOutput &&
                 ['passed', 'failed', 'timed_out'].indexOf(
                     this.ioSubStepProps(i, false, 'state'),
                 ) !== -1

--- a/src/components/AutoTestSuite.vue
+++ b/src/components/AutoTestSuite.vue
@@ -65,6 +65,7 @@
                                     :index="i + 1"
                                     :test-types="stepTypes"
                                     :assignment="assignment"
+                                    :is-continuous="isContinuous"
                                     @delete="internalValue.removeItem(i)"
                                     editable/>
                 </SlickItem>
@@ -248,6 +249,7 @@
                             :key="step.trackingId"
                             :index="i + 1"
                             :result="result"
+                            :is-continuous="isContinuous"
                             :assignment="assignment" />
         </table>
     </b-card>
@@ -280,30 +282,29 @@ export default {
             type: Object,
             required: true,
         },
-
         assignment: {
             type: Object,
             required: true,
         },
-
         otherSuites: {
             type: Array,
             required: true,
         },
-
         editable: {
             type: Boolean,
             default: false,
         },
-
         editing: {
             type: Boolean,
             default: false,
         },
-
         result: {
             type: Object,
             default: null,
+        },
+        isContinuous: {
+            type: Boolean,
+            default: false,
         },
     },
 

--- a/src/components/IPythonViewer.vue
+++ b/src/components/IPythonViewer.vue
@@ -152,7 +152,7 @@ export default {
         },
 
         feedback() {
-            return this.submission.feedback.user[this.fileId] || {};
+            return this.$utils.getProps(this.submission, {}, 'feedback', 'user', this.fileId);
         },
 
         sourceLanguage() {

--- a/src/pages/Submission.vue
+++ b/src/pages/Submission.vue
@@ -363,21 +363,29 @@ export default {
         },
 
         loadingInner() {
-            const canSeeFeedback = this.canSeeFeedback;
-            const feedback = this.feedback;
-            const fileTree = this.fileTree;
-            const currentFile = this.currentFile;
-            const autoTestId = this.autoTestId;
-            const autoTest = this.autoTest;
-            const loadingPermissions = this.loadingPermissions !== null;
+            const {
+                canSeeFeedback,
+                feedback,
+                fileTree,
+                currentFile,
+                canViewAutoTest,
+                autoTest,
+                loadingPermissions,
+            } = this;
 
             return (
                 (canSeeFeedback && !feedback) ||
                 !fileTree ||
                 !currentFile ||
-                (autoTestId && !autoTest) ||
-                loadingPermissions
+                (canViewAutoTest && !autoTest) ||
+                loadingPermissions !== null
             );
+        },
+
+        canViewAutoTest() {
+            const { autoTestId, assignmentDone, canViewAutoTestBeforeDone } = this;
+
+            return autoTestId && (assignmentDone || canViewAutoTestBeforeDone);
         },
 
         showTeacherDiff() {
@@ -603,6 +611,7 @@ export default {
                         'can_view_own_teacher_files',
                         'can_edit_others_work',
                         'can_see_grade_history',
+                        'can_view_autotest_before_done',
                     ],
                     this.courseId,
                 ),
@@ -616,6 +625,7 @@ export default {
                         ownTeacher,
                         editOthersWork,
                         canSeeGradeHistory,
+                        canViewAutoTestBeforeDone,
                     ],
                     canUseSnippets,
                 ]) => {
@@ -624,8 +634,8 @@ export default {
                         this.canSeeFeedback = canSeeGradeBeforeDone || this.assignmentDone;
                         this.canDeleteSubmission = canDeleteSubmission;
                         this.canSeeGradeHistory = canSeeGradeHistory;
-
                         this.canUseSnippets = canUseSnippets;
+                        this.canViewAutoTestBeforeDone = canViewAutoTestBeforeDone;
 
                         if (
                             this.submission &&


### PR DESCRIPTION
* Fix confirmation message of the AssignmentState button on an LMS instance.
* Make Continuous Feedback visible to students before assignment is done.
* Make AutoTest tests less flaky.
* Fix AutoTest permission message.
* Fix error if feedback isn't set.
* Fix loadingInner on submission page.
* Fix weird AutoTestRun reloading bug where the results would constantly disappear and appear again.