### PR TITLE
Move loading of code to FileViewer component

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -1,6 +1,20 @@
 Changelog
 ==========
 
+Version *Next*
+-----------------
+
+**Released**: Unreleased
+
+**Updates**
+- Various internal improvements (`#1244
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1244>`__). This makes it easier
+  to improve CodeGrade in the future.
+
+**Fixes**
+- Make sure that empty markdown files show a useful errors `(#1244)
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1244>`__.
+
 Version Knoet.3
 -----------------
 

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -7,11 +7,13 @@ Version *Next*
 **Released**: *Unreleased*
 
 **Updates**
+
 - Various internal improvements (`#1244
   <https://github.com/CodeGra-de/CodeGra.de/pull/1244>`__). This makes it easier
   to improve CodeGrade in the future.
 
 **Fixes**
+
 - Make sure that empty markdown files show a useful errors `(#1244)
   <https://github.com/CodeGra-de/CodeGra.de/pull/1244>`__.
 

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Version *Next*
 -----------------
 
-**Released**: Unreleased
+**Released**: *Unreleased*
 
 **Updates**
 - Various internal improvements (`#1244

--- a/src/components/CodeViewer.vue
+++ b/src/components/CodeViewer.vue
@@ -83,6 +83,16 @@ export default {
         ...mapGetters('pref', ['fontSize']),
         ...mapGetters('feedback', ['getFeedback']),
 
+        canSeeAssignee() {
+            return this.$utils.getProps(
+                this.assignment,
+                false,
+                'course',
+                'permissions',
+                'can_see_assignee',
+            );
+        },
+
         feedbackEditable() {
             return this.editable && this.studentMode;
         },
@@ -162,22 +172,15 @@ export default {
         return {
             selectedLanguage: 'Default',
             languages,
-            canSeeAssignee: false,
         };
     },
 
-    mounted() {
-        Promise.all([
-            this.loadSettings(),
-            this.$hasPermission('can_see_assignee', this.assignment.course.id),
-        ]).then(([, assignee]) => {
-            this.canSeeAssignee = assignee;
-        });
-    },
-
     watch: {
-        fileId() {
-            this.loadSettings();
+        fileId: {
+            immediate: true,
+            handler() {
+                this.loadSettings();
+            },
         },
 
         language(lang) {
@@ -194,7 +197,7 @@ export default {
     methods: {
         loadSettings() {
             this.selectedLanguage = null;
-            return this.$hlanguageStore.getItem(`${this.file.id}`).then(lang => {
+            return this.$hlanguageStore.getItem(this.fileId).then(lang => {
                 if (lang !== null) {
                     this.$emit('language', lang);
                     this.selectedLanguage = lang;

--- a/src/components/CodeViewer.vue
+++ b/src/components/CodeViewer.vue
@@ -188,9 +188,6 @@ export default {
                 return;
             }
             this.selectedLanguage = lang;
-            if (!this.isLargeFile) {
-                this.highlightCode(lang);
-            }
         },
     },
 

--- a/src/components/DiffViewer.vue
+++ b/src/components/DiffViewer.vue
@@ -62,6 +62,10 @@ export default {
             type: Object,
             required: true,
         },
+        fileId: {
+            type: String,
+            required: true,
+        },
         showWhitespace: {
             type: Boolean,
             default: true,
@@ -81,13 +85,14 @@ export default {
         };
     },
 
-    mounted() {
-        this.getCode();
-    },
-
     watch: {
-        file(f) {
-            if (f) this.getCode();
+        fileId: {
+            immediate: true,
+            handler(id) {
+                if (id) {
+                    this.getCode(this.fileId);
+                }
+            },
         },
     },
 
@@ -96,7 +101,7 @@ export default {
             storeLoadCode: 'loadCode',
         }),
 
-        getCode() {
+        getCode(fileId) {
             let error = '';
 
             const promises = this.file.ids.map(id => {
@@ -120,7 +125,9 @@ export default {
                             return;
                         }
 
-                        this.diffCode(origCode, revCode);
+                        if (fileId === this.fileId) {
+                            this.diffCode(origCode, revCode);
+                        }
                     },
                     err => {
                         error = err;
@@ -128,9 +135,12 @@ export default {
                 )
                 .then(() => {
                     if (error) {
-                        this.$emit('error', error);
+                        this.$emit('error', {
+                            error,
+                            fileId,
+                        });
                     } else {
-                        this.$emit('load');
+                        this.$emit('load', fileId);
                     }
                 });
         },

--- a/src/components/FileViewer.vue
+++ b/src/components/FileViewer.vue
@@ -213,6 +213,8 @@ export default {
         dynamicClasses() {
             if (this.showEmptyFileMessage) {
                 return 'empty-file-wrapper border rounded';
+            } else if (this.showError) {
+                return 'rounded';
             } else if (this.fileData) {
                 return `${this.fileData.component.name} border rounded ${
                     this.fileContent ? '' : 'no-data'

--- a/src/components/FileViewer.vue
+++ b/src/components/FileViewer.vue
@@ -365,7 +365,7 @@ export default {
     display: flex;
     flex-direction: column;
 
-    &.html-viewer:not(.no-data) {
+    &.html-viewer {
         height: 100%;
     }
     &.pdf-viewer:not(.no-data) {

--- a/src/components/FileViewer.vue
+++ b/src/components/FileViewer.vue
@@ -291,6 +291,9 @@ export default {
                         this.storeLoadCode(fileId),
                         this.$afterRerender(),
                     ]);
+                    // We have to call `onLoad` manually when the content is
+                    // empty, because no viewer component will be loaded to
+                    // emit a `load` event.
                     if (content.byteLength === 0) {
                         callback = () => this.onLoad(fileId);
                     }

--- a/src/components/FileViewer.vue
+++ b/src/components/FileViewer.vue
@@ -30,8 +30,8 @@
          :class="{ scroller: fileData && fileData.scroller }"
          v-if="!showError">
         <div v-if="showEmptyFileMessage"
-             class="wrapper px-3 py-1 text-muted">
-            <small>This file is empty.</small>
+             class="px-3 py-2 font-italic text-muted">
+            This file is empty.
         </div>
         <template v-else-if="fileData">
             <component v-show="dataAvailable"
@@ -212,7 +212,7 @@ export default {
 
         dynamicClasses() {
             if (this.showEmptyFileMessage) {
-                return 'empty-file-wrapper form-control';
+                return 'empty-file-wrapper border rounded';
             } else if (this.fileData) {
                 return `${this.fileData.component.name} border rounded ${
                     this.fileContent ? '' : 'no-data'

--- a/src/components/FileViewer.vue
+++ b/src/components/FileViewer.vue
@@ -181,9 +181,9 @@ export default {
         showEmptyFileMessage() {
             return (
                 !this.loading &&
-                    this.fileData &&
-                    this.fileContent &&
-                    this.fileContent.byteLength === 0
+                this.fileData &&
+                this.fileContent &&
+                this.fileContent.byteLength === 0
             );
         },
 
@@ -237,14 +237,16 @@ export default {
         dataAvailable() {
             return (
                 this.fileData &&
-                    !this.loading &&
-                    (this.fileContent != null || !this.fileData.needsContent)
+                !this.loading &&
+                (this.fileContent != null || !this.fileData.needsContent)
             );
         },
 
         showError() {
-            return this.error ||
-                (this.fileData && this.showDiff(this.file) && !this.fileData.supportsDiff);
+            return (
+                this.error ||
+                (this.fileData && this.showDiff(this.file) && !this.fileData.supportsDiff)
+            );
         },
     },
 
@@ -280,10 +282,11 @@ export default {
                             callback = () => this.onLoad(newVal);
                         }
                     } catch (e) {
-                        callback = () => this.onError({
-                            error: e,
-                            fileId: newVal,
-                        });
+                        callback = () =>
+                            this.onError({
+                                error: e,
+                                fileId: newVal,
+                            });
                     }
 
                     if (newVal === this.fileId) {

--- a/src/components/HtmlViewer.vue
+++ b/src/components/HtmlViewer.vue
@@ -147,7 +147,7 @@ export default {
             immediate: true,
             handler() {
                 this.setDefaultOptions();
-                this.$emit('load');
+                this.$emit('load', this.fileId);
                 if (this.isMyFile) {
                     this.getIframeSrc().then(
                         data => {

--- a/src/components/IPythonViewer.vue
+++ b/src/components/IPythonViewer.vue
@@ -81,13 +81,13 @@ export default {
                 return [];
             }
 
-            function error(err) {
+            const error = err => {
                 this.$emit('error', {
                     error: err,
                     fileId: this.fileId,
                 });
                 return [];
-            }
+            };
 
             let jsonString;
             try {

--- a/src/components/IPythonViewer.vue
+++ b/src/components/IPythonViewer.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters } from 'vuex';
 
 import decodeBuffer from '@/utils/decode';
 import { getOutputCells } from '@/utils/ipython';
@@ -65,27 +65,55 @@ export default {
             type: String,
             default: 'The file is not a valid IPython notebook.',
         },
-    },
-
-    data() {
-        return {
-            outputCells: this.cells,
-        };
+        fileContent: {
+            required: true,
+        },
     },
 
     computed: {
         ...mapGetters('pref', ['fontSize']),
-
         feedback() {
             return this.$utils.getProps(this.submission, {}, 'feedback', 'user', this.fileId);
+        },
+
+        outputCells() {
+            if (this.fileId == null || this.fileContent == null) {
+                return [];
+            }
+
+            function error(err) {
+                this.$emit('error', {
+                    error: err,
+                    fileId: this.fileId,
+                });
+                return [];
+            }
+
+            let jsonString;
+            try {
+                jsonString = decodeBuffer(this.fileContent);
+            } catch (e) {
+                return error(e);
+            }
+
+            let data;
+            try {
+                data = JSON.parse(jsonString);
+            } catch (e) {
+                return error(this.invalidJsonMessage);
+            }
+
+            try {
+                const res = Object.freeze(getOutputCells(data));
+                this.$emit('load', this.fileId);
+                return res;
+            } catch (e) {
+                return error(e);
+            }
         },
     },
 
     methods: {
-        ...mapActions('code', {
-            storeLoadCode: 'loadCode',
-        }),
-
         outputData(output, types) {
             for (let i = 0; i < types.length; ++i) {
                 if (output.data[types[i]]) {
@@ -93,43 +121,6 @@ export default {
                 }
             }
             return null;
-        },
-
-        async loadCode() {
-            this.outputCells = this.cells;
-            if (this.fileId == null) {
-                return;
-            }
-
-            let jsonString;
-            await this.$afterRerender();
-
-            try {
-                const code = await this.storeLoadCode(this.fileId);
-                jsonString = decodeBuffer(code);
-            } catch (e) {
-                this.outputCells = [];
-                this.$emit('error', e);
-                return;
-            }
-
-            try {
-                const data = JSON.parse(jsonString);
-                this.outputCells = Object.freeze(getOutputCells(data));
-                this.$emit('load');
-            } catch (e) {
-                this.outputCells = [];
-                this.$emit('error', this.invalidJsonMessage);
-            }
-        },
-    },
-
-    watch: {
-        fileId: {
-            immediate: true,
-            handler() {
-                this.loadCode();
-            },
         },
     },
 

--- a/src/components/MarkdownViewer.vue
+++ b/src/components/MarkdownViewer.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapGetters } from 'vuex';
 import decodeBuffer from '@/utils/decode';
 
 import InnerMarkdownViewer from './InnerMarkdownViewer';
@@ -46,6 +46,10 @@ export default {
             type: Object,
             default: null,
         },
+        fileId: {
+            type: String,
+            required: true,
+        },
         editable: {
             type: Boolean,
             default: false,
@@ -62,20 +66,13 @@ export default {
             type: Boolean,
             required: true,
         },
-    },
-
-    data() {
-        return {
-            data: null,
-        };
+        fileContent: {
+            required: true,
+        },
     },
 
     computed: {
         ...mapGetters('pref', ['fontSize']),
-
-        fileId() {
-            return this.file.id || this.file.ids[0] || this.file.ids[1];
-        },
 
         line() {
             return 0;
@@ -91,32 +88,23 @@ export default {
                 this.line,
             );
         },
-    },
 
-    methods: {
-        ...mapActions('code', {
-            storeLoadCode: 'loadCode',
-        }),
-
-        async loadCode() {
-            this.data = '';
-            await this.$afterRerender();
+        data() {
+            if (this.fileContent == null) {
+                return '';
+            }
 
             try {
-                this.data = decodeBuffer(await this.storeLoadCode(this.fileId));
-                this.$emit('load');
-            } catch (e) {
-                this.$emit('error', e);
+                const res = decodeBuffer(this.fileContent);
+                this.$emit('load', this.fileId);
+                return res;
+            } catch (error) {
+                this.$emit('error', {
+                    error,
+                    fileId: this.fileId,
+                });
+                return '';
             }
-        },
-    },
-
-    watch: {
-        fileId: {
-            immediate: true,
-            handler() {
-                this.loadCode();
-            },
         },
     },
 

--- a/src/components/PdfViewer.vue
+++ b/src/components/PdfViewer.vue
@@ -126,15 +126,12 @@ export default {
                         }?not_as_attachment&mime=application/pdf`;
                     },
                     err => {
-                        this.$emit(
-                            'error',
-                            {
-                                error: `An error occured while loading the PDF: ${this.$utils.getErrorMessage(
-                                    err,
-                                )}.`,
-                                fileId,
-                            },
-                        );
+                        this.$emit('error', {
+                            error: `An error occured while loading the PDF: ${this.$utils.getErrorMessage(
+                                err,
+                            )}.`,
+                            fileId,
+                        });
                     },
                 );
             } else if (this.fileContent == null) {

--- a/src/main.js
+++ b/src/main.js
@@ -66,6 +66,11 @@ axios.defaults.transformResponse = [
     function defaultTransformResponse(data, headers) {
         switch (headers['content-type']) {
             case 'application/json':
+                // Somehow axios gives us an ArrayBuffer sometimes, even though
+                // the Content-Type header is application/json. JSON.parse does
+                // not work on ArrayBuffers (they're silently converted to the
+                // string "[object ArrayBuffer]", which is invalid JSON), so we
+                // must do that ourselves.
                 if (data instanceof ArrayBuffer) {
                     const view = new Int8Array(data);
                     const dataStr = String.fromCharCode.apply(null, view);

--- a/src/main.js
+++ b/src/main.js
@@ -66,6 +66,11 @@ axios.defaults.transformResponse = [
     function defaultTransformResponse(data, headers) {
         switch (headers['content-type']) {
             case 'application/json':
+                if (data instanceof ArrayBuffer) {
+                    const view = new Int8Array(data);
+                    const dataStr = String.fromCharCode.apply(null, view);
+                    return JSON.parse(dataStr);
+                }
                 return JSON.parse(data);
             default:
                 return data;

--- a/src/store/modules/code.js
+++ b/src/store/modules/code.js
@@ -47,14 +47,20 @@ const actions = {
             .get(`/api/v1/code/${codeId}`, {
                 responseType: 'arraybuffer',
             })
-            .then(code => {
-                context.commit(types.SET_CODE_CACHE, {
-                    codeId,
-                    code: code.data,
-                });
-                clearLoader();
-                return code.data;
-            }, clearLoader);
+            .then(
+                code => {
+                    context.commit(types.SET_CODE_CACHE, {
+                        codeId,
+                        code: code.data,
+                    });
+                    clearLoader();
+                    return code.data;
+                },
+                err => {
+                    clearLoader();
+                    throw err;
+                },
+            );
 
         Vue.set(loaders.codeLoaders, codeId, promise);
         return promise;

--- a/test/unit/specs/DiffViewer.spec.js
+++ b/test/unit/specs/DiffViewer.spec.js
@@ -46,6 +46,7 @@ describe('diffCode in DiffViewer.vue', () => {
         },
         propsData: {
             file: { ids: [] },
+            fileId: `${Math.random()}`,
         },
         store: new Vuex.Store({
             modules: {

--- a/test/unit/specs/IPythonViewer.spec.js
+++ b/test/unit/specs/IPythonViewer.spec.js
@@ -5,6 +5,8 @@ import VueRouter from 'vue-router';
 import Vuex from 'vuex';
 import BootstrapVue from 'bootstrap-vue';
 import * as utils from '@/utils';
+import * as decode from '@/utils/decode'
+import * as ipythonUtils from '@/utils/ipython'
 import axios from 'axios';
 import util from 'util';
 
@@ -58,9 +60,9 @@ describe('IPythonViewer.vue', () => {
         await comp.$afterRerender();
     };
 
-    beforeEach(() => {
-        utils.highlightCode = jest.fn(a => a);
-        fileId = `$(Math.random())`;
+    beforeEach(async () => {
+        jest.spyOn(utils, 'highlightCode').mockImplementation(x => x);
+        fileId = `${Math.random()}`;
 
         curId = Math.round(Math.random() * 1000);
         assignment = { id: curId++ };
@@ -84,7 +86,7 @@ describe('IPythonViewer.vue', () => {
             resolve({ data: res });
         }));
 
-        axios.get = mockGet;
+        jest.spyOn(axios, 'get').mockImplementation(mockGet);
 
         wrapper = shallowMount(IPythonViewer, {
             localVue,
@@ -131,7 +133,7 @@ describe('IPythonViewer.vue', () => {
     });
 
     afterEach(() => {
-        utils.highlightCode.mockRestore();
+        jest.restoreAllMocks();
     });
 
     describe('outputCells', () => {
@@ -233,20 +235,46 @@ describe('IPythonViewer.vue', () => {
     });
 
     describe('loadCode', () => {
-        let emitMock;
-
-        beforeEach(() => {
-            const oldEmit = comp.$emit;
-            emitMock = jest.fn(err => oldEmit.call(comp, err));
-            comp.$emit = emitMock;
-        });
-
         it('should work when the api returns invalid JSON', async () => {
             await setData('THIS IS NOT JSON');
-            expect(emitMock).toBeCalledWith('error', {
+            expect(wrapper.emitted().error).toEqual([[{
                 error: comp.invalidJsonMessage,
                 fileId: fileId,
-            });
+            }]]);
+        });
+
+        it('should work when the buffer cannot be decoded', async () => {
+            const err = Math.random();
+            const error = new Error(err)
+            jest.spyOn(decode, 'default').mockImplementation(
+                () => { throw error; },
+            )
+            wrapper.setProps({ fileContent: 'AAH' });
+
+            await comp.$nextTick();
+            await comp.$nextTick();
+            await comp.$nextTick();
+
+            expect(decode.default).toBeCalledWith('AAH');
+            expect(wrapper.emitted().error).toEqual([[{
+                error,
+                fileId: fileId,
+            }]]);
+        });
+
+        it('should work when getOutputCells errors', async () => {
+            const err = Math.random();
+            const error = new Error(err)
+            jest.spyOn(ipythonUtils, 'getOutputCells')
+                .mockImplementation(() => { throw error; });
+
+            await setData('{"val": "AAAH"}');
+
+            expect(ipythonUtils.getOutputCells).toBeCalledWith({ val: 'AAAH' });
+            expect(wrapper.emitted().error).toEqual([[{
+                error,
+                fileId: fileId,
+            }]]);
         });
     });
 

--- a/test/unit/specs/IPythonViewer.spec.js
+++ b/test/unit/specs/IPythonViewer.spec.js
@@ -56,7 +56,6 @@ describe('IPythonViewer.vue', () => {
         mockIPython = (new util.TextEncoder()).encode(str);
         wrapper.setProps({ fileContent: mockIPython });
 
-        await comp.loadCode();
         await comp.$afterRerender();
     };
 


### PR DESCRIPTION
## Description
This makes each viewer component easier, as they do not need to handle async state. This also fixes a bug where nothing would be shown on empty markdown files.