### PR TITLE
Release version Knoet.2.2

### DIFF
--- a/cypress/integration/tests/rubric-viewer.spec.js
+++ b/cypress/integration/tests/rubric-viewer.spec.js
@@ -148,6 +148,12 @@ context('Rubric Viewer', () => {
         const rubricRows = new Rubric(...rubricPoints);
         let rubric;
 
+        function setMaxPoints(maxPoints) {
+            cy.createRubric(assignment.id, rubricRows, maxPoints);
+            cy.reload();
+            cy.get('.rubric-viewer').should('be.visible');
+        }
+
         after(() => {
             cy.deleteRubric(assignment.id);
         });
@@ -217,13 +223,24 @@ context('Rubric Viewer', () => {
             checkGrade('10.00');
         });
 
-        it('should take the rubric\'s max points into account calculating the rubric grade', () => {
-            function setMaxPoints(maxPoints) {
-                cy.createRubric(assignment.id, rubricRows, maxPoints);
-                cy.reload();
-                cy.get('.rubric-viewer').should('be.visible');
+        it('should display the correct max points in the grade viewer', () => {
+            function checkMaxPoints(maxPoints) {
+                cy.get('.grade-viewer .rubric-score')
+                    .should('contain', `/ ${maxPoints}`);
             }
 
+            checkMaxPoints(12);
+            setMaxPoints(1);
+            checkMaxPoints(1);
+            setMaxPoints(10);
+            checkMaxPoints(10);
+            setMaxPoints(10.12345);
+            checkMaxPoints(10.12);
+            setMaxPoints(null);
+            checkMaxPoints(12);
+        });
+
+        it('should take the rubric\'s max points into account calculating the rubric grade', () => {
             setMaxPoints(1);
             selectRubricItem(0);
             checkGrade('10.00');

--- a/psef/lti.py
+++ b/psef/lti.py
@@ -114,9 +114,9 @@ class LTIRole(abc.ABC):
     def __lt__(self, other: object) -> bool:
         """Check if this item is less than the other item.
 
-        >>> a = LTICourseRole(name='Mentor', subnames=['c'])
+        >>> a = LTICourseRole(name='Instructor', subnames=['c'])
         >>> b = LTICourseRole(name='Learner', subnames=['c'])
-        >>> c = LTIGlobalRole(name='Mentor', subnames=['c'])
+        >>> c = LTIGlobalRole(name='Instructor', subnames=['c'])
         >>> a < b
         False
         >>> a > b
@@ -179,7 +179,6 @@ class LTICourseRole(LTIRole):
         'Instructor': ('Teacher', 3),
         'ContentDeveloper': ('Designer', 1),
         'Member': ('Student', 0),
-        'Mentor': ('TA', 2),
         'Administrator': ('Teacher', 3),
         'TeachingAssistant': ('TA', 2),
     }
@@ -210,7 +209,6 @@ class LTIGlobalRole(LTIRole):
         'Member': ('Student', 2),
         'Learner': ('Student', 2),
         'Instructor': ('Staff', 3),
-        'Mentor': ('Staff', 3),
         'Staff': ('Staff', 3),
         'Alumni': ('Student', 2),
         'ProspectiveStudent': ('Student', 2),

--- a/src/components/GradeViewer.vue
+++ b/src/components/GradeViewer.vue
@@ -206,18 +206,11 @@ export default {
         },
 
         rubricPoints() {
-            return this.rubricResult && this.rubricResult.points;
+            return this.$utils.getProps(this.rubricResult, null, 'points');
         },
 
         rubricMaxPoints() {
-            if (this.rubric == null) {
-                return null;
-            }
-            return this.$utils.getProps(
-                this.assignment,
-                this.rubric.maxPoints,
-                'fixed_max_rubric_points',
-            );
+            return this.$utils.getProps(this.rubricResult, null, 'maxPoints');
         },
 
         rubricHasSelectedItems() {
@@ -225,10 +218,7 @@ export default {
         },
 
         rubricGrade() {
-            if (this.rubric == null || this.rubricResult == null) {
-                return null;
-            }
-            return this.rubricResult.getGrade(this.rubricMaxPoints);
+            return this.$utils.getProps(this.rubricResult, null, 'grade');
         },
 
         isRubricChanged() {

--- a/src/components/RubricViewer.vue
+++ b/src/components/RubricViewer.vue
@@ -242,10 +242,16 @@ export default {
     }
 
     .row-description {
+        position: relative;
         max-height: 6.66rem;
         overflow: auto;
         line-height: 1.3;
         background-color: rgba(0, 0, 0, 0.0625);
+
+        .rubric-lock {
+            position: sticky;
+            top: 0.5rem;
+        }
     }
 
     .progress-meter {

--- a/src/components/RubricViewerContinuousRow.vue
+++ b/src/components/RubricViewerContinuousRow.vue
@@ -5,8 +5,12 @@
      @mouseenter="lockPopoverVisible = true"
      @mouseleave="lockPopoverVisible = false">
     <div class="rubric-row-header">
-        <div class="row-description border-bottom py-2 px-3">
+        <div class="row-description border-bottom">
             <template v-if="locked">
+                <icon name="lock"
+                      class="rubric-lock float-right mx-3 my-2"
+                      :id="`rubric-lock-${id}`" />
+
                 <!-- We need to key this popover to make sure it actually
                      changes when the content changes. -->
                 <b-popover :show="lockPopoverVisible"
@@ -14,15 +18,12 @@
                            :content="lockPopover"
                            :key="lockPopover"
                            triggers=""
-                           placement="top" />
-
-                <icon name="lock"
-                      class="float-right mt-1"
-                      :id="`rubric-lock-${id}`" />
+                           placement="top"
+                           boundary="window" />
             </template>
 
-            <p class="text-wrap-pre mb-0" v-if="rubricRow.description">{{ rubricRow.description }}</p>
-            <p class="mb-0 text-muted font-italic" v-else>
+            <p class="text-wrap-pre mb-0 py-2 px-3" v-if="rubricRow.description">{{ rubricRow.description }}</p>
+            <p class="mb-0 py-2 px-3 text-muted font-italic" v-else>
                 This category has no description.
             </p>
         </div>

--- a/src/components/RubricViewerNormalRow.vue
+++ b/src/components/RubricViewerNormalRow.vue
@@ -4,8 +4,12 @@
      :class="{ editable, locked }"
      @mouseenter="lockPopoverVisible = true"
      @mouseleave="lockPopoverVisible = false">
-    <div class="row-description border-bottom py-2 px-3">
+    <div class="row-description border-bottom">
         <template v-if="locked">
+            <icon name="lock"
+                  class="rubric-lock float-right mx-3 my-2"
+                  :id="`rubric-lock-${id}`" />
+
             <!-- We need to key this popover to make sure it actually
                  changes when the content changes. -->
             <b-popover :show="lockPopoverVisible"
@@ -13,15 +17,12 @@
                        :content="lockPopover"
                        :key="lockPopover"
                        triggers=""
-                       placement="top" />
-
-            <icon name="lock"
-                  class="float-right mt-1"
-                  :id="`rubric-lock-${id}`" />
+                       placement="top"
+                       boundary="window" />
         </template>
 
-        <p class="text-wrap-pre mb-0" v-if="rubricRow.description">{{ rubricRow.description }}</p>
-        <p class="mb-0 text-muted font-italic" v-else>
+        <p class="text-wrap-pre mb-0 py-2 px-3" v-if="rubricRow.description">{{ rubricRow.description }}</p>
+        <p class="mb-0 py-2 px-3 text-muted font-italic" v-else>
             This category has no description.
         </p>
     </div>

--- a/src/models/rubric.js
+++ b/src/models/rubric.js
@@ -431,16 +431,29 @@ export class RubricResult {
         return store.getters['submissions/getSingleSubmission'](this.submissionId);
     }
 
+    get assignment() {
+        return getProps(this.submission, null, 'assignment');
+    }
+
     get rubric() {
         const id = getProps(this.submission, null, 'assignmentId');
         return id == null ? null : store.getters['rubrics/rubrics'][id];
     }
 
-    getGrade(maxPoints) {
-        if (this.nSelected === 0) {
+    get maxPoints() {
+        // TODO: Move this to the Rubric model and get it from this.rubric.
+        return getProps(
+            this.assignment,
+            getProps(this.rubric, null, 'maxPoints'),
+            'fixed_max_rubric_points',
+        );
+    }
+
+    get grade() {
+        if (this.nSelected === 0 || this.maxPoints == null) {
             return null;
         } else {
-            const grade = 10 * this.points / maxPoints;
+            const grade = 10 * this.points / this.maxPoints;
             return formatGrade(Math.max(0, Math.min(grade, 10)));
         }
     }


### PR DESCRIPTION
* The "Mentor" role of LTI users is now ignored, rather than giving them the same permissions as TAs.
* Fix padding on the rubric row descriptions in the RubricViewer.
* Fix boundary of the lock popovers in the RubricViewer.
* Lock lock icon in place in the RubricViewer.