### PR TITLE
Test rubric editor when user can't view AutoTest

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Upload to coveralls
         run: coveralls
+        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS }}
 

--- a/cypress/integration/tests/rubric-editor.spec.js
+++ b/cypress/integration/tests/rubric-editor.spec.js
@@ -913,33 +913,13 @@ context('Rubric Editor', () => {
         });
 
         it('should indicate which rows are connected to AutoTest', () => {
-            const rubric = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
-            cy.createRubric(assignment.id, rubric).then(res =>
-                cy.createAutoTest(assignment.id, {
-                    sets: [{
-                        suites: [{
-                            rubric_row_id: res[0].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 1',
-                                data: { program: 'true' },
-                            }],
-                        }, {
-                            rubric_row_id: res[2].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 2',
-                                data: { program: 'true' },
-                            }],
-                        }],
-                    }],
-                }),
+            const rubricData = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
+            cy.createRubric(assignment.id, rubricData).then(rubric =>
+                cy.createAutoTestFromFixture(
+                    assignment.id,
+                    'single_cat_two_items',
+                    rubric,
+                ),
             ).then(autoTest => {
                 loadPage(true);
 

--- a/cypress/integration/tests/rubric-editor.spec.js
+++ b/cypress/integration/tests/rubric-editor.spec.js
@@ -720,7 +720,7 @@ context('Rubric Editor', () => {
         });
 
         it('should indicate which rows are connected to AutoTest', () => {
-            const rubric = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
+            const rubricData = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
             cy.createRubric(assignment.id, rubricData).then(rubric =>
                 cy.createAutoTestFromFixture(
                     assignment.id,

--- a/cypress/integration/tests/rubric-editor.spec.js
+++ b/cypress/integration/tests/rubric-editor.spec.js
@@ -721,32 +721,12 @@ context('Rubric Editor', () => {
 
         it('should indicate which rows are connected to AutoTest', () => {
             const rubric = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
-            cy.createRubric(assignment.id, rubric).then(res =>
-                cy.createAutoTest(assignment.id, {
-                    sets: [{
-                        suites: [{
-                            rubric_row_id: res[0].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 1',
-                                data: { program: 'true' },
-                            }],
-                        }, {
-                            rubric_row_id: res[2].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 2',
-                                data: { program: 'true' },
-                            }],
-                        }],
-                    }],
-                }),
+            cy.createRubric(assignment.id, rubricData).then(rubric =>
+                cy.createAutoTestFromFixture(
+                    assignment.id,
+                    'single_cat_two_items',
+                    rubric,
+                ),
             ).then(autoTest => {
                 loadPage(true);
 
@@ -1006,7 +986,13 @@ context('Rubric Editor', () => {
                 loadPage(false);
                 cy.get('.rubric-editor')
                     .should('not.have.class', 'alert')
-                    .should('be.visible');
+                    .should('be.visible')
+                    .find('[id^="rubric-lock-"]:visible')
+                    .trigger('mouseenter');
+                cy.get('.popover')
+                    .should('be.visible')
+                    .should('have.length', 1)
+                    .should('not.contain', 'Grade calculation');
 
                 cy.deleteAutoTest(autoTest.id);
             });

--- a/cypress/integration/tests/rubric-editor.spec.js
+++ b/cypress/integration/tests/rubric-editor.spec.js
@@ -45,9 +45,16 @@ context('Rubric Editor', () => {
 
     before(() => {
         cy.visit('/');
-        cy.createCourse(`Rubric Editor Course ${unique}`).then(res => {
+        cy.createCourse(
+            `Rubric Editor Course ${unique}`,
+            [{ name: 'student1', role: 'Student' }],
+        ).then(res => {
             course = res;
-            cy.createAssignment(course.id, `Rubric Editor Assignment ${unique}`).then(res => {
+            cy.createAssignment(
+                course.id,
+                `Rubric Editor Assignment ${unique}`,
+                { state: 'open', deadline: 'tomorrow' },
+            ).then(res => {
                 assignment = res;
             });
         });
@@ -978,6 +985,30 @@ context('Rubric Editor', () => {
                     .click();
                 cy.get('.rubric-editor .rubric-editor-row.continuous:visible p')
                     .shouldNotOverflow();
+            });
+        });
+
+        it('should be visible even if the user does not have the permission to see the AutoTest', () => {
+            const rubricData = new Rubric([1], [1], [0, 1, 2], [0, 1, 2]);
+            cy.createRubric(assignment.id, rubricData).then(rubric =>
+                cy.createAutoTestFromFixture(
+                    assignment.id,
+                    'no_continuous',
+                    rubric,
+                ),
+            ).then(autoTest => {
+                loadPage(true);
+                cy.get('.rubric-editor')
+                    .should('not.have.class', 'alert')
+                    .should('be.visible');
+
+                cy.login('student1', 'Student1');
+                loadPage(false);
+                cy.get('.rubric-editor')
+                    .should('not.have.class', 'alert')
+                    .should('be.visible');
+
+                cy.deleteAutoTest(autoTest.id);
             });
         });
     });

--- a/cypress/integration/tests/rubric-viewer.spec.js
+++ b/cypress/integration/tests/rubric-viewer.spec.js
@@ -363,33 +363,13 @@ context('Rubric Viewer', () => {
         before(() => {
             cy.createRubric(assignment.id, rubricRows).then(res => {
                 rubric = res;
-                cy.createAutoTest(assignment.id, {
-                    sets: [{
-                        suites: [{
-                            rubric_row_id: rubric[0].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 1',
-                                data: { program: 'true' },
-                            }],
-                        }, {
-                            rubric_row_id: rubric[2].id,
-                            network_disabled: true,
-                            steps: [{
-                                type: 'run_program',
-                                weight: 1,
-                                hidden: false,
-                                name: 'step 2',
-                                data: { program: 'true' },
-                            }],
-                        }],
-                    }],
-                }).then(res => {
-                    autoTest = res;
-                });
+                return cy.createAutoTestFromFixture(
+                    assignment.id,
+                    'single_cat_two_items',
+                    rubric,
+                );
+            }).then(res => {
+                autoTest = res;
             });
         });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -349,6 +349,7 @@ Cypress.Commands.add('deleteSubmission', (submissionId) => {
     return cy.authRequest({
         url: `/api/v1/submissions/${submissionId}`,
         method: 'DELETE',
+        user: ADMIN_USER,
     });
 });
 
@@ -356,6 +357,7 @@ Cypress.Commands.add('patchSubmission', (submissionId, body) => {
     return cy.authRequest({
         url: `/api/v1/submissions/${submissionId}`,
         method: 'PATCH',
+        user: ADMIN_USER,
         body,
     }).its('body');
 });
@@ -364,6 +366,7 @@ Cypress.Commands.add('clearRubricResult', (submissionId) => {
     return cy.authRequest({
         url: `/api/v1/submissions/${submissionId}/rubricitems/`,
         method: 'PATCH',
+        user: ADMIN_USER,
         body: {
             items: [],
         },
@@ -374,6 +377,7 @@ Cypress.Commands.add('createRubric', (assignmentId, rubricData, maxPoints = null
     return cy.authRequest({
         url: `/api/v1/assignments/${assignmentId}/rubrics/`,
         method: 'PUT',
+        user: ADMIN_USER,
         body: {
             rows: rubricData,
             max_points: maxPoints,
@@ -385,6 +389,7 @@ Cypress.Commands.add('deleteRubric', (assignmentId, opts={}) => {
     return cy.authRequest({
         url: `/api/v1/assignments/${assignmentId}/rubrics/`,
         method: 'DELETE',
+        user: ADMIN_USER,
         ...opts,
     });
 });
@@ -399,6 +404,7 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) => {
     return cy.authRequest({
         url: '/api/v1/auto_tests/',
         method: 'POST',
+        user: ADMIN_USER,
         body: {
             assignment_id: assignmentId,
         },
@@ -407,6 +413,7 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) => {
             cy.authRequest({
                 url: `/api/v1/auto_tests/${autoTest.id}`,
                 method: 'PATCH',
+                user: ADMIN_USER,
                 body: patchProps,
             });
         }
@@ -414,16 +421,19 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) => {
             cy.authRequest({
                 url: `/api/v1/auto_tests/${autoTest.id}/sets/`,
                 method: 'POST',
+                user: ADMIN_USER,
             }).its('body').then(set =>
                 cy.authRequest({
                     url: `/api/v1/auto_tests/${autoTest.id}/sets/${set.id}`,
                     method: 'PATCH',
+                    user: ADMIN_USER,
                     body: { stop_points: setConfig.stop_points },
                 }).then(() =>
                     cy.wrap(setConfig.suites).each(suiteConfig =>
                         cy.authRequest({
                             url: `/api/v1/auto_tests/${autoTest.id}/sets/${set.id}/suites/`,
                             method: 'PATCH',
+                            user: ADMIN_USER,
                             body: suiteConfig,
                         }),
                     ),
@@ -434,6 +444,7 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) => {
             cy.authRequest({
                 url: `/api/v1/auto_tests/${autoTest.id}`,
                 method: 'GET',
+                user: ADMIN_USER,
             }).its('body'),
         );
     });
@@ -461,6 +472,7 @@ Cypress.Commands.add('deleteAutoTest', (autoTestId) => {
     return cy.authRequest({
         url: `/api/v1/auto_tests/${autoTestId}`,
         method: 'DELETE',
+        user: ADMIN_USER,
     });
 });
 
@@ -468,6 +480,7 @@ Cypress.Commands.add('connectGroupSet', (courseId, assignmentId, minSize=1, maxS
     return cy.authRequest({
         url: `/api/v1/courses/${courseId}/group_sets/`,
         method: 'PUT',
+        user: ADMIN_USER,
         body: {
             minimum_size: minSize,
             maximum_size: maxSize,
@@ -489,11 +502,13 @@ Cypress.Commands.add('joinGroup', (groupSetId, username) => {
     return cy.authRequest({
         url: `/api/v1/group_sets/${groupSetId}/group`,
         method: 'POST',
+        user: ADMIN_USER,
         body: { member_ids: [] },
     }).its('body').then(
         group => cy.authRequest({
             url: `/api/v1/groups/${group.id}/member`,
             method: 'POST',
+            user: ADMIN_USER,
             body: { username },
         }),
     );

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -417,6 +417,7 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) =>
                 ),
             ),
         ).then(() =>
+            // Get the object again so we're sure we have the latest.
             cy.authRequest({
                 url: `/api/v1/auto_tests/${autoTest.id}`,
                 method: 'GET',
@@ -424,6 +425,24 @@ Cypress.Commands.add('createAutoTest', (assignmentId, autoTestConfig) =>
         ),
     ),
 );
+
+Cypress.Commands.add('createAutoTestFromFixture', (assignmentId, autoTest, rubric) => {
+    // Since AutoTest categories must map to a rubric category, we must know
+    // the rubric row's id in advance before we can submit the AutoTest config.
+    // This function loads a fixture from the test_auto_tests fixture
+    // subdirectory and patches its rubric row ids with the ones in the given
+    // rubric. The rubric row ids in the fixture represent rubric row indices.
+
+    cy.fixture(`test_auto_tests/${autoTest}.json`).then(autoTestConfig => {
+        autoTestConfig.sets.forEach(set => {
+            set.suites.forEach(suite => {
+                const idx = suite.rubric_row_id;
+                suite.rubric_row_id = rubric[idx].id;
+            });
+        });
+        return cy.createAutoTest(assignmentId, autoTestConfig);
+    });
+});
 
 Cypress.Commands.add('deleteAutoTest', (autoTestId) => {
     return cy.authRequest({

--- a/src/components/AutoTestState.vue
+++ b/src/components/AutoTestState.vue
@@ -19,8 +19,6 @@
 </template>
 
 <script>
-import moment from 'moment';
-
 import Icon from 'vue-awesome/components/Icon';
 import 'vue-awesome/icons/ban';
 import 'vue-awesome/icons/check';
@@ -107,18 +105,8 @@ export default {
             }
         },
 
-        startMSec() {
-            const startedAt = this.result.startedAt;
-            return (
-                startedAt &&
-                moment(startedAt)
-                    .utc()
-                    .valueOf()
-            );
-        },
-
         passedSinceStart() {
-            return Math.max(0, (this.$root.$epoch - this.startMSec) / 1000);
+            return Math.max(0, this.$root.$epoch.diff(this.result.startedAt, 'seconds'));
         },
 
         minutes() {

--- a/src/components/GradeViewer.vue
+++ b/src/components/GradeViewer.vue
@@ -301,7 +301,7 @@ export default {
             };
             const points = this.rubricPoints;
             const scored = points ? toFixed(points) : 0;
-            const max = toFixed(this.rubricMaxPoints);
+            const max = this.rubricMaxPoints == null ? '…' : toFixed(this.rubricMaxPoints);
             return `${scored} / ${max}`;
         },
 

--- a/src/main.js
+++ b/src/main.js
@@ -248,9 +248,7 @@ localforage.defineDriver(memoryStorageDriver).then(() => {
     };
 
     function getUTCEpoch() {
-        const d = new Date();
-        const offset = 60 * 1000 * d.getTimezoneOffset();
-        return d.getTime() + offset;
+        return moment();
     }
 
     /* eslint-disable no-new */
@@ -267,6 +265,11 @@ localforage.defineDriver(memoryStorageDriver).then(() => {
                 smallWidth: 628,
                 mediumWidth: 768,
                 largeWidth: 992,
+                // `Now` and `epoch` both contain the current time. They are
+                // the same, except that `epoch` is recalculated every second
+                // while `now` is set only every minute. We do not want `now`
+                // to be updated as often because that would trigger a redraw
+                // of the sidebar every second.
                 now: moment(),
                 epoch: getUTCEpoch(),
             };

--- a/src/models/rubric.js
+++ b/src/models/rubric.js
@@ -256,7 +256,7 @@ export class NormalRubricRow extends RubricRow {
             msg += `You need to reach the ${
                 gradeCalculation === 'full' ? 'upper' : 'lower'
             } bound of a rubric item to achieve its score.`;
-        } else {
+        } else if (autoTest != null) {
             msg += 'No grade calculation method has been set yet.';
         }
 

--- a/src/store/modules/submissions.js
+++ b/src/store/modules/submissions.js
@@ -125,13 +125,12 @@ const actions = {
 
         if (context.state.submissionsByUserPromises[assignmentId][userId] == null) {
             const promise = axios
-                .get(`/api/v1/assignments/${assignmentId}/users/${userId}/submissions/`)
+                .get(`/api/v1/assignments/${assignmentId}/users/${userId}/submissions/?extended`)
                 .then(({ data: subs }) => {
-                    const submissions = subs.map(sub =>
-                        Submission.fromServerData(sub, assignmentId),
-                    );
-                    submissions.forEach(sub => {
-                        context.commit(types.ADD_SINGLE_SUBMISSION, { submission: sub });
+                    subs.forEach(sub => {
+                        context.commit(types.ADD_SINGLE_SUBMISSION, {
+                            submission: Submission.fromServerData(sub, assignmentId),
+                        });
                         if (sub.rubric_result != null) {
                             commitRubricResult(context.commit, sub.id, sub.rubric_result);
                         }

--- a/test/unit/specs/rubrics.spec.js
+++ b/test/unit/specs/rubrics.spec.js
@@ -592,11 +592,10 @@ describe('The rubric store', () => {
                     locked: 'auto_test',
                 }));
 
-                expect(row.lockMessage(null, null, null)).toBe('This is an AutoTest category.');
+                expect(row.lockMessage(null, null, null).startsWith('This is an AutoTest category.')).toBeTrue();
             });
 
             it('should get the correct message for a not filled in rubric with a result', () => {
-
                 const atResult = new AutoTestResult({
                     id: 5,
                     work_id: 6,

--- a/test/unit/specs/rubrics.spec.js
+++ b/test/unit/specs/rubrics.spec.js
@@ -592,7 +592,7 @@ describe('The rubric store', () => {
                     locked: 'auto_test',
                 }));
 
-                expect(row.lockMessage(null, null, null)).toBe('This is an AutoTest category. No grade calculation method has been set yet.');
+                expect(row.lockMessage(null, null, null)).toBe('This is an AutoTest category.');
             });
 
             it('should get the correct message for a not filled in rubric with a result', () => {

--- a/test_data/test_auto_tests/no_continuous.json
+++ b/test_data/test_auto_tests/no_continuous.json
@@ -1,0 +1,18 @@
+{
+    "results_always_visible": false,
+    "sets": [{
+        "suites": [{
+            "rubric_row_id": 0,
+            "network_disabled": true,
+            "steps": [{
+                "type": "run_program",
+                "weight": 1,
+                "hidden": false,
+                "name": "step 1",
+                "data": {
+                    "program": "true"
+                }
+            }]
+        }]
+    }]
+}

--- a/test_data/test_auto_tests/single_cat_two_items.json
+++ b/test_data/test_auto_tests/single_cat_two_items.json
@@ -1,0 +1,29 @@
+{
+    "sets": [{
+        "suites": [{
+            "rubric_row_id": 0,
+            "network_disabled": true,
+            "steps": [{
+                "type": "run_program",
+                "weight": 1,
+                "hidden": false,
+                "name": "step 1",
+                "data": {
+                    "program": "true"
+                }
+            }]
+        }, {
+            "rubric_row_id": 2,
+            "network_disabled": true,
+            "steps": [{
+                "type": "run_program",
+                "weight": 1,
+                "hidden": false,
+                "name": "step 2",
+                "data": {
+                    "program": "true"
+                }
+            }]
+        }]
+    }]
+}


### PR DESCRIPTION
* Add tests for the fixes in #1269.
* Only show "No grade calculation" message in the rubric viewer lock popover when the user has permission to view the AutoTest details.
* Fix issue storing rubric results after loading submissions by user.
* Show an ellipsis in the rubric max points in the grade viewer when the rubric result hasn't loaded yet.
* Fix AutoTest timers: due to the changes to how dates are represented the timers would always display `00:00`.