### PR TITLE
Fix AutoTest timers

### DIFF
--- a/src/components/AutoTestState.vue
+++ b/src/components/AutoTestState.vue
@@ -19,8 +19,6 @@
 </template>
 
 <script>
-import moment from 'moment';
-
 import Icon from 'vue-awesome/components/Icon';
 import 'vue-awesome/icons/ban';
 import 'vue-awesome/icons/check';
@@ -107,18 +105,8 @@ export default {
             }
         },
 
-        startMSec() {
-            const startedAt = this.result.startedAt;
-            return (
-                startedAt &&
-                moment(startedAt)
-                    .utc()
-                    .valueOf()
-            );
-        },
-
         passedSinceStart() {
-            return Math.max(0, (this.$root.$epoch - this.startMSec) / 1000);
+            return Math.max(0, this.$root.$epoch.diff(this.result.startedAt, 'seconds'));
         },
 
         minutes() {

--- a/src/main.js
+++ b/src/main.js
@@ -248,9 +248,7 @@ localforage.defineDriver(memoryStorageDriver).then(() => {
     };
 
     function getUTCEpoch() {
-        const d = new Date();
-        const offset = 60 * 1000 * d.getTimezoneOffset();
-        return d.getTime() + offset;
+        return moment();
     }
 
     /* eslint-disable no-new */
@@ -267,6 +265,11 @@ localforage.defineDriver(memoryStorageDriver).then(() => {
                 smallWidth: 628,
                 mediumWidth: 768,
                 largeWidth: 992,
+                // `Now` and `epoch` both contain the current time. They are
+                // the same, except that `epoch` is recalculated every second
+                // while `now` is set only every minute. We do not want `now`
+                // to be updated as often because that would trigger a redraw
+                // of the sidebar every second.
                 now: moment(),
                 epoch: getUTCEpoch(),
             };


### PR DESCRIPTION
Because of the changes to how dates are represented the AutoTest timers would not display the correct time anymore.