### PR TITLE
[DEV-88] Do not discard changed rubric viewer when saving general feedback

### DIFF
--- a/src/components/GradeViewer.vue
+++ b/src/components/GradeViewer.vue
@@ -405,8 +405,9 @@ export default {
                 case DeleteButtonState.RUBRIC_OVERRIDDEN:
                     return this.clearSubmissionGrade();
                 case DeleteButtonState.CLEAR_RUBRIC:
-                    return this.clearRubricItems().then(() => {
+                    return this.clearRubricItems().then(res => {
                         this.$root.$emit('cg::rubric-viewer::reset');
+                        return res;
                     });
                 case DeleteButtonState.RUBRIC_CHANGED_AND_OVERRIDDEN:
                     return {

--- a/src/components/GradeViewer.vue
+++ b/src/components/GradeViewer.vue
@@ -405,7 +405,9 @@ export default {
                 case DeleteButtonState.RUBRIC_OVERRIDDEN:
                     return this.clearSubmissionGrade();
                 case DeleteButtonState.CLEAR_RUBRIC:
-                    return this.clearRubricItems();
+                    return this.clearRubricItems().then(() => {
+                        this.$root.$emit('cg::rubric-viewer::reset');
+                    });
                 case DeleteButtonState.RUBRIC_CHANGED_AND_OVERRIDDEN:
                     return {
                         data: {

--- a/src/components/RubricViewer.vue
+++ b/src/components/RubricViewer.vue
@@ -142,17 +142,14 @@ export default {
 
         selectedItems() {
             const selected = this.$utils.getProps(this.internalResult, {}, 'selected');
-            return Object.entries(selected).reduce(
-                (acc, [rowId, item]) => {
-                    const points = parseFloat(item.points);
-                    const mult = parseFloat(item.multiplier);
-                    if (!Number.isNaN(points) && !Number.isNaN(mult)) {
-                        acc[rowId] = mult * points;
-                    }
-                    return acc;
-                },
-                {},
-            );
+            return Object.entries(selected).reduce((acc, [rowId, item]) => {
+                const points = parseFloat(item.points);
+                const mult = parseFloat(item.multiplier);
+                if (!Number.isNaN(points) && !Number.isNaN(mult)) {
+                    acc[rowId] = mult * points;
+                }
+                return acc;
+            }, {});
         },
 
         autoTestConfigId() {

--- a/src/components/RubricViewer.vue
+++ b/src/components/RubricViewer.vue
@@ -214,17 +214,13 @@ export default {
     },
 
     mounted() {
-        this.$root.$on('cg::rubric-viewer::open-category', id => {
-            this.currentCategory = this.rubric.rows.findIndex(row => row.id === id);
-        });
-        this.$root.$on('cg::rubric-viewer::reset', () => {
-            this.reset();
-        });
+        this.$root.$on('cg::rubric-viewer::open-category', this.gotoCategory);
+        this.$root.$on('cg::rubric-viewer::reset', this.reset);
     },
 
     destroyed() {
-        this.$root.$off('cg::rubric-viewer::open-category');
-        this.$root.$off('cg::rubric-viewer::reset');
+        this.$root.$off('cg::rubric-viewer::open-category', this.gotoCategory);
+        this.$root.$off('cg::rubric-viewer::reset', this.reset);
     },
 
     methods: {
@@ -245,6 +241,10 @@ export default {
 
         reset() {
             this.changedItems = {};
+        },
+
+        gotoCategory(rowId) {
+            this.currentCategory = this.rubric.rows.findIndex(row => row.id === rowId);
         },
     },
 

--- a/src/components/RubricViewer.vue
+++ b/src/components/RubricViewer.vue
@@ -186,7 +186,7 @@ export default {
         submissionId: {
             immediate: true,
             handler() {
-                this.changedItems = {};
+                this.reset();
 
                 this.storeLoadRubricResult({
                     submissionId: this.submissionId,
@@ -217,10 +217,14 @@ export default {
         this.$root.$on('cg::rubric-viewer::open-category', id => {
             this.currentCategory = this.rubric.rows.findIndex(row => row.id === id);
         });
+        this.$root.$on('cg::rubric-viewer::reset', () => {
+            this.reset();
+        });
     },
 
     destroyed() {
         this.$root.$off('cg::rubric-viewer::open-category');
+        this.$root.$off('cg::rubric-viewer::reset');
     },
 
     methods: {
@@ -237,6 +241,10 @@ export default {
         resultUpdated(rowId, item) {
             this.$set(this.changedItems, rowId, item);
             this.$emit('input', this.internalResult);
+        },
+
+        reset() {
+            this.changedItems = {};
         },
     },
 

--- a/src/components/RubricViewerContinuousRow.vue
+++ b/src/components/RubricViewerContinuousRow.vue
@@ -188,8 +188,6 @@ export default {
             clearTimeout(this.timerId);
 
             const inputEl = this.$refs.multiplierInput;
-            const rowId = this.rubricRow.id;
-            const item = this.onlyItem;
 
             let value = parseFloat(inputEl.value);
             if (!Number.isNaN(value)) {
@@ -200,15 +198,13 @@ export default {
                 return;
             }
 
-            const newResult = this.value.setMultiplier(rowId, item, value);
-
             if (delay) {
                 this.timerId = setTimeout(() => {
                     this.timerId = null;
-                    this.$emit('input', newResult);
+                    this.emitItem(value);
                 }, this.timerDelay);
             } else {
-                this.$emit('input', newResult);
+                this.emitItem(value);
             }
         },
 
@@ -218,6 +214,14 @@ export default {
             this.$nextTick(() => {
                 this.$emit('submit');
             });
+        },
+
+        emitItem(multiplier) {
+            if (multiplier == null) {
+                this.$emit('input', null);
+            } else {
+                this.$emit('input', Object.assign({}, this.onlyItem, { multiplier }));
+            }
         },
     },
 

--- a/src/components/RubricViewerNormalRow.vue
+++ b/src/components/RubricViewerNormalRow.vue
@@ -167,9 +167,10 @@ export default {
                 return;
             }
 
-            const rowId = this.rubricRow.id;
-            const value = this.value.toggleItem(rowId, item);
-            this.$emit('input', value);
+            this.$emit(
+                'input',
+                item.id === this.selectedId ? null : Object.assign({}, item, { multiplier: 1 }),
+            );
         },
     },
 


### PR DESCRIPTION
Whenever a rubric result changed in the store (e.g. because its submission changed, or the AutoTest results updated it) it was set as the current result in the RubricViewer, discarding any changes that were made. This changes that so we now keep the changes that were made and apply those to the store result to get the current state.

Blocked by #1259 as this is based on that PR

DEV-88 #finished