### PR TITLE
[DEV-87] Render all whitespace in all <code> elements

### DIFF
--- a/src/components/UsersManager.vue
+++ b/src/components/UsersManager.vue
@@ -56,9 +56,8 @@
                         <td class="align-middle">
                             <div class="d-flex">
                                 <code style="word-break: break-all"
-                                      :style="{ textDecoration: isLinkExpired(link) ? 'line-through' : 'none' }">
-                                    {{ getRegistrationLinkUrl(link) }}
-                                </code>
+                                      :style="{ textDecoration: isLinkExpired(link) ? 'line-through' : 'none' }"
+                                      >{{ getRegistrationLinkUrl(link) }}</code>
                             </div>
                         </td>
                     </template>

--- a/src/components/WebhookInstructions.vue
+++ b/src/components/WebhookInstructions.vue
@@ -246,7 +246,7 @@
             to hand in your current repository, you can do this by an empty
             commit.
             You can run
-            <code>git commit --allow-empty -m "Create a CodeGrade submission" &amp;&amp; git push</code>
+            <code class="d-block p-3">git commit --allow-empty -m "Create a CodeGrade submission" &amp;&amp; git push</code>
             while the {{ data.default_branch }} branch is checked out. If you
             are using a GUI for Git that does not support empty commits, simply
             making an arbitrary change in a tracked file will allow you to

--- a/src/components/WebhookInstructions.vue
+++ b/src/components/WebhookInstructions.vue
@@ -99,9 +99,8 @@
         </p>
 
         <div class="border rounded p-3 copy-wrapper">
-            <code class="public-key">
-                {{ data.public_key }}
-            </code>
+            <code class="public-key">{{ data.public_key }}</code>
+
             <b-btn class="copy-btn m-1 fixed" v-if="copying || copyMsg" disabled>
                 <loader :scale="1" v-if="copying" />
                 <template v-else>
@@ -236,10 +235,9 @@
         <p>
             {{ providerName }} should now be successfully configured. Now, the
             content of your repository will be automatically uploaded for this
-            CodeGrade assignment every time you perform a <code>git push
-            </code>. You can test this by pushing to the
-            {{ data.default_branch }} branch and checking if a new submission
-            was created.
+            CodeGrade assignment every time you perform a <code>git push</code>.
+            You can test this by pushing to the {{ data.default_branch }}
+            branch and checking if a new submission was created.
         </p>
         <p>
             A good practice is to set up the {{ providerName }} CodeGrade
@@ -248,11 +246,11 @@
             to hand in your current repository, you can do this by an empty
             commit.
             You can run
-            <code>git commit --allow-empty -m "Create a CodeGrade submission"
-                &amp;&amp; git push</code> while the {{ data.default_branch }}
-            branch is checked out. If you are using a GUI for Git that does not
-            support empty commits, simply making an arbitrary change in a
-            tracked file will allow you to still do a <code>git push</code>.
+            <code>git commit --allow-empty -m "Create a CodeGrade submission" &amp;&amp; git push</code>
+            while the {{ data.default_branch }} branch is checked out. If you
+            are using a GUI for Git that does not support empty commits, simply
+            making an arbitrary change in a tracked file will allow you to
+            still do a <code>git push</code>.
         </p>
         <p>
             You have now successfully setup your {{ providerName }} CodeGrade

--- a/src/style.less
+++ b/src/style.less
@@ -21,6 +21,10 @@ html {
     box-sizing: inherit;
 }
 
+code {
+    white-space: pre-wrap;
+}
+
 .form-control {
     .default-form-control-colors;
 }


### PR DESCRIPTION
`<code>` elements did not have the `white-space: pre-wrap` CSS property set, meaning that multiple consecutive wthitespaces would be collapsed, which was annoying in AutoTest commands where whitespace is significant... This PR changes sets that property on all `<code>` elements and fixes the places where this would cause a difference with how it was rendered previously.

DEV-87 #done