### PR TITLE
Add a minimum amount of free space check to the health route

### DIFF
--- a/config.py
+++ b/config.py
@@ -138,6 +138,7 @@ FlaskConfig = TypedDict(
         'SESSION_COOKIE_SAMESITE': Literal['None', 'Strict', 'Lax'],
         'SESSION_COOKIE_SECURE': bool,
         'SENTRY_DSN': t.Optional[str],
+        'MIN_FREE_DISK_SPACE': int,
     },
     total=True
 )
@@ -341,6 +342,9 @@ set_str(CONFIG, backend_ops, 'JAVA_PATH', 'java')
 set_str(CONFIG, backend_ops, 'JPLAG_JAR', 'jplag.jar')
 
 set_str(CONFIG, backend_ops, 'SENTRY_DSN', None)
+
+GB = 1024 ** 3
+set_int(CONFIG, backend_ops, 'MIN_FREE_DISK_SPACE', 10 * GB)
 
 
 def _set_version() -> None:

--- a/psef/files.py
+++ b/psef/files.py
@@ -907,13 +907,21 @@ def split_path(path: str) -> t.Tuple[t.Sequence[str], bool]:
     return patharr, is_dir
 
 
-def check_dir(path: str) -> bool:
-    '''Check if the path is a directory that is readable, writable, and
+def check_dir(path: str, *, check_size: bool = False) -> bool:
+    """Check if the path is a directory that is readable, writable, and
     executable for the current user.
 
     :param path: Path to check.
+    :param check_size: Also check if there is enough free space in the given
+        directory.
     :returns: ``True`` if path has the properties described above, ``False``
         otherwise.
-    '''
+    """
     mode = os.R_OK | os.W_OK | os.X_OK
-    return os.access(path, mode) and os.path.isdir(path)
+    res = os.access(path, mode) and os.path.isdir(path)
+
+    if res and check_size:
+        free_space = shutil.disk_usage(path).free
+        res = free_space > app.config['MIN_FREE_DISK_SPACE']
+
+    return res

--- a/psef/v1/about.py
+++ b/psef/v1/about.py
@@ -6,6 +6,7 @@ running psef.
 SPDX-License-Identifier: AGPL-3.0-only
 """
 import typing as t
+import tempfile
 
 import structlog
 from flask import request
@@ -58,8 +59,11 @@ def about(
             logger.error('Database not working', exc_info=True)
             database = False
 
-        uploads = check_dir(current_app.config['UPLOAD_DIR'])
-        mirror_uploads = check_dir(current_app.config['MIRROR_UPLOAD_DIR'])
+        uploads = check_dir(current_app.config['UPLOAD_DIR'], check_size=True)
+        mirror_uploads = check_dir(
+            current_app.config['MIRROR_UPLOAD_DIR'], check_size=True
+        )
+        temp_dir = check_dir(tempfile.gettempdir(), check_size=True)
 
         with helpers.BrokerSession() as ses:
             try:
@@ -78,6 +82,7 @@ def about(
             'uploads': uploads,
             'broker': broker_ok,
             'mirror_uploads': mirror_uploads,
+            'temp_dir': temp_dir,
         }
         res['health'] = health_value
 

--- a/psef_test/test_about.py
+++ b/psef_test/test_about.py
@@ -72,6 +72,7 @@ def test_about_health_status(
                 'database': True,
                 'uploads': True,
                 'mirror_uploads': True,
+                'temp_dir': True,
                 'broker': True,
             },
         }
@@ -95,6 +96,7 @@ def test_about_health_status(
                 'database': False,
                 'uploads': True,
                 'mirror_uploads': True,
+                'temp_dir': True,
                 'broker': True,
             },
         },
@@ -124,6 +126,7 @@ def test_about_health_status(
                 'database': True,
                 'uploads': True,
                 'mirror_uploads': True,
+                'temp_dir': True,
                 'broker': False,
             },
         },
@@ -132,3 +135,23 @@ def test_about_health_status(
     # We shouldn't do any retrying or anything
     assert len(stub_session_cls.all_calls) == 1
     stub_session_cls.reset_cls()
+
+    monkeypatch.setitem(app.config, 'MIN_FREE_DISK_SPACE', float('inf'))
+    test_client.req(
+        'get',
+        '/api/v1/about',
+        500,
+        query={'health': 'good key'},
+        result={
+            'version': object,
+            'features': dict,
+            'health': {
+                'application': True,
+                'database': True,
+                'uploads': False,
+                'mirror_uploads': False,
+                'temp_dir': False,
+                'broker': True,
+            },
+        },
+    )

--- a/psef_test/test_about.py
+++ b/psef_test/test_about.py
@@ -58,6 +58,7 @@ def test_about_health_status(
             return self()
 
     monkeypatch.setattr(models.Permission, 'get_all_permissions', Inspect())
+    monkeypatch.setitem(app.config, 'MIN_FREE_DISK_SPACE', 0)
 
     test_client.req(
         'get',


### PR DESCRIPTION
This checks that we have enough space available in all directories we use for
writing. As we currently run all CodeGrade instance on a single disk volume it
is not really necessary to check each directory individually but it doesn't hurt
either.