### PR TITLE
[DEV-185] Fix creating job in finished state

### DIFF
--- a/cg_broker/api.py
+++ b/cg_broker/api.py
@@ -178,9 +178,10 @@ def delete_job(job_id: str) -> EmptyResponse:
 
         # Make sure job will never be able to run
         job = models.Job(
-            cg_url=request.headers['CG-Broker-Instance'], remote_id=job_id
+            cg_url=request.headers['CG-Broker-Instance'],
+            remote_id=job_id,
+            state=models.JobState.finished
         )
-        job.state = models.JobState.finished
         db.session.add(job)
         db.session.commit()
         return EmptyResponse.make()

--- a/cg_broker/api.py
+++ b/cg_broker/api.py
@@ -180,7 +180,7 @@ def delete_job(job_id: str) -> EmptyResponse:
         job = models.Job(
             cg_url=request.headers['CG-Broker-Instance'],
             remote_id=job_id,
-            state=models.JobState.finished
+            state=models.JobState.finished,
         )
         db.session.add(job)
         db.session.commit()

--- a/cg_broker/models.py
+++ b/cg_broker/models.py
@@ -585,6 +585,13 @@ class Job(Base, mixins.TimestampMixin, mixins.IdMixin):
 
     state = hybrid_property(_get_state, _set_state)
 
+    def __init__(self, remote_id: str, cg_url: str, state: JobState = JobState.waiting_for_runner) -> None:
+        super().__init__(
+            remote_id=remote_id,
+            cg_url=cg_url,
+            _state=state,
+        )
+
     def get_active_runners(self) -> t.List[Runner]:
         return [
             r for r in self.runners

--- a/cg_broker/models.py
+++ b/cg_broker/models.py
@@ -585,7 +585,12 @@ class Job(Base, mixins.TimestampMixin, mixins.IdMixin):
 
     state = hybrid_property(_get_state, _set_state)
 
-    def __init__(self, remote_id: str, cg_url: str, state: JobState = JobState.waiting_for_runner) -> None:
+    def __init__(
+        self,
+        remote_id: str,
+        cg_url: str,
+        state: JobState = JobState.waiting_for_runner,
+    ) -> None:
         super().__init__(
             remote_id=remote_id,
             cg_url=cg_url,


### PR DESCRIPTION
Fix creating a job in the broker in finished state, earlier we tried to set
`state` after creating the job, however as the default value for `_state` wasn't
yet set the `_set_state` function crashed. Now we make it possible to set an
initial state using the `__init__` method.

DEV-185 #done