### PR TITLE
[DEV-187] Retry adjust amount of runners in broker

### DIFF
--- a/psef/tasks.py
+++ b/psef/tasks.py
@@ -524,7 +524,11 @@ def _check_heartbeat_stop_test_runner_1(auto_test_runner_id: str) -> None:
     p.models.db.session.commit()
 
 
-@celery.task
+@celery.task(
+    autoretry_for=(RequestException, ),
+    retry_backoff=True,
+    retry_kwargs={'max_retries': 15}
+)
 def _adjust_amount_runners_1(auto_test_run_id: int) -> None:
     run = p.models.AutoTestRun.query.filter_by(
         id=auto_test_run_id


### PR DESCRIPTION
This task also contacts the broker, so we should retry it if the requests to the
broker fail.

DEV-187 #done