### PR TITLE
[DEV-189] Fix error when deleting submission by test student

### DIFF
--- a/psef/models/lti_provider.py
+++ b/psef/models/lti_provider.py
@@ -29,7 +29,7 @@ class LTIProvider(Base):
     key = db.Column('key', db.Unicode, unique=True, nullable=False)
 
     @staticmethod
-    def _get_sourcedids_to_passback(sub: 'Work') -> t.Iterable[int]:
+    def _get_sourcedids_to_passback(sub: 'Work') -> t.Iterable[str]:
         for user in sub.get_all_authors():
             # We do not need to passback grades for test students, as they are
             # not of a real user.

--- a/psef/models/work.py
+++ b/psef/models/work.py
@@ -482,10 +482,6 @@ class Work(Base):
             result so that the real grade won't show as too late.
         :returns: Nothing
         """
-        if self.user.is_test_student:
-            # We do not need to passback these grades, as they are not of a
-            # real user.
-            return
         lti_provider = self.assignment.course.lti_provider
         assert lti_provider
 


### PR DESCRIPTION
If you deleted the newest submission of a test student while there was a older
submission the celery task to passback the grade failed. This PR moves all
filtering of the test student from passing back into a single method on the
LTIProvider.