### PR TITLE
Fix login action in user store

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -37,18 +37,15 @@ const getters = {
 const actions = {
     login({ commit, dispatch }, response) {
         commit(types.LOGIN, response.data);
-        return Promise.all([
-            actions.refreshSnippets({ commit }),
-            dispatch(
-                'users/addOrUpdateUser',
-                {
-                    user: response.data.user,
-                },
-                {
-                    root: true,
-                },
-            ),
-        ]);
+        return dispatch(
+            'users/addOrUpdateUser',
+            {
+                user: response.data.user,
+            },
+            {
+                root: true,
+            },
+        );
     },
 
     addSnippet({ commit }, snippet) {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -35,9 +35,20 @@ const getters = {
 };
 
 const actions = {
-    login({ commit }, response) {
+    login({ commit, dispatch }, response) {
         commit(types.LOGIN, response.data);
-        actions.refreshSnippets({ commit });
+        return Promise.all([
+            actions.refreshSnippets({ commit }),
+            dispatch(
+                'users/addOrUpdateUser',
+                {
+                    user: response.data.user,
+                },
+                {
+                    root: true,
+                },
+            ),
+        ]);
     },
 
     addSnippet({ commit }, snippet) {


### PR DESCRIPTION
Unlike the verifyLogin action in the user store, the login action does
not add the logged in user to the users store. This causes an error on
pages that do not explicitly load users, such as on the manage
assignment page, where the submission uploader shows the name of the
logged in user by default.