### PR TITLE
Fix deleting directory with deleted files

### DIFF
--- a/psef/v1/code.py
+++ b/psef/v1/code.py
@@ -317,10 +317,11 @@ def delete_code(file_id: int) -> EmptyResponse:
 
     # We already know that the Work exists, so we can safely use
     # child.self_deleted.
-    if not all(
-        child.fileowner == other
-        for child in code.children.all() if not child.self_deleted
-    ):
+    if db.session.query(
+        code.children.filter(
+            ~models.File.self_deleted, models.File.fileowner != other
+        ).exists(),
+    ).scalar():
         raise APIException(
             'You cannot delete this directory as it has children',
             f'The file "{file_id}" has children with fileowner "{current}"',

--- a/psef/v1/code.py
+++ b/psef/v1/code.py
@@ -315,7 +315,12 @@ def delete_code(file_id: int) -> EmptyResponse:
     else:
         current, other = models.FileOwner.teacher, models.FileOwner.student
 
-    if not all(child.fileowner == other for child in code.children.all()):
+    # We already know that the Work exists, so we can safely use
+    # child.self_deleted.
+    if not all(
+        child.fileowner == other
+        for child in code.children.all() if not child.self_deleted
+    ):
         raise APIException(
             'You cannot delete this directory as it has children',
             f'The file "{file_id}" has children with fileowner "{current}"',

--- a/psef_test/test_code.py
+++ b/psef_test/test_code.py
@@ -508,14 +508,14 @@ def test_delete_code_twice(
     'filename', ['../test_submissions/multiple_dir_archive.zip'],
     indirect=True
 )
-def test_delete_dir_with_deleted_files(
-    assignment_real_works, test_client, request, error_template, ta_user,
-    student_user, logged_in, session, describe
+def test_delete_dir_with_deleted_files_as_student(
+    assignment_real_works, test_client, request, error_template, student_user,
+    logged_in, session, describe
 ):
     assignment, work = assignment_real_works
     work_id = work['id']
 
-    with logged_in(student_user), describe('as a student'):
+    with logged_in(student_user):
         res = test_client.req(
             'get',
             f'/api/v1/submissions/{work_id}/files/',
@@ -573,13 +573,23 @@ def test_delete_dir_with_deleted_files(
                 result={
                     'id': str,
                     'name': str,
-                    'entries': list,
+                    'entries': [dict],
                 },
             )
-            print(res)
-            assert len(res['entries']) == 1
 
-    with logged_in(ta_user), describe('as a teacher'):
+
+@pytest.mark.parametrize(
+    'filename', ['../test_submissions/multiple_dir_archive.zip'],
+    indirect=True
+)
+def test_delete_dir_with_deleted_files_as_ta(
+    assignment_real_works, test_client, request, error_template, ta_user,
+    logged_in, session, describe
+):
+    assignment, work = assignment_real_works
+    work_id = work['id']
+
+    with logged_in(ta_user):
         res = test_client.req(
             'get',
             f'/api/v1/submissions/{work_id}/files/',
@@ -591,7 +601,6 @@ def test_delete_dir_with_deleted_files(
                 'entries': list,
             },
         )
-        print(res)
         assert len(res['entries']) == 2
         dir = res['entries'][0]
         assert 'entries' in dir
@@ -636,7 +645,7 @@ def test_delete_dir_with_deleted_files(
             )
 
         with describe('check that directory is gone'):
-            res = test_client.req(
+            test_client.req(
                 'get',
                 f'/api/v1/submissions/{work_id}/files/',
                 200,
@@ -644,22 +653,9 @@ def test_delete_dir_with_deleted_files(
                 result={
                     'id': str,
                     'name': str,
-                    'entries': list,
+                    'entries': [dict],
                 },
             )
-            res2 = test_client.req(
-                'get',
-                f'/api/v1/submissions/{work_id}/files/',
-                200,
-                result={
-                    'id': str,
-                    'name': str,
-                    'entries': list,
-                },
-            )
-            print(res)
-            print(res2)
-            assert len(res['entries']) == 1
 
 
 @pytest.mark.parametrize(

--- a/src/utils/typed.ts
+++ b/src/utils/typed.ts
@@ -8,9 +8,9 @@ import { Maybe } from 'purify-ts/Maybe';
 import { User } from '@/models';
 import { visualizeWhitespace } from './visualize';
 
-export * from 'purify-ts/Either';
-export * from 'purify-ts/EitherAsync';
-export * from 'purify-ts/Maybe';
+export * from 'purify-ts/es/Either';
+export * from 'purify-ts/es/EitherAsync';
+export * from 'purify-ts/es/Maybe';
 
 export type ValueOf<T> = T[keyof T];
 

--- a/src/utils/typed.ts
+++ b/src/utils/typed.ts
@@ -8,9 +8,9 @@ import { Maybe } from 'purify-ts/Maybe';
 import { User } from '@/models';
 import { visualizeWhitespace } from './visualize';
 
-export * from 'purify-ts/es/Either';
-export * from 'purify-ts/es/EitherAsync';
-export * from 'purify-ts/es/Maybe';
+export * from 'purify-ts/Either';
+export * from 'purify-ts/EitherAsync';
+export * from 'purify-ts/Maybe';
 
 export type ValueOf<T> = T[keyof T];
 


### PR DESCRIPTION
We did not account for the new way of deleting files (by only setting a flag) in the code that checks if a directory has children, so we would not treat files whose `deleted` flag was set as such. This fixes that and adds a test that we can only delete directories if all their children are deleted.