### PR TITLE
DEV-152 Always show students' own comments in feedback overview

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -26,7 +26,8 @@ Version *Next*
   `(#1328) <https://github.com/CodeGra-de/CodeGra.de/pull/1328>`__,
   `(#1331) <https://github.com/CodeGra-de/CodeGra.de/pull/1331>`__,
   `(#1332) <https://github.com/CodeGra-de/CodeGra.de/pull/1332>`__,
-  `(#1333) <https://github.com/CodeGra-de/CodeGra.de/pull/1333>`__.
+  `(#1333) <https://github.com/CodeGra-de/CodeGra.de/pull/1333>`__,
+  `(#1352) <https://github.com/CodeGra-de/CodeGra.de/pull/1352>`__.
 
 Version LowVoltage
 -------------------

--- a/src/components/FeedbackOverview.vue
+++ b/src/components/FeedbackOverview.vue
@@ -6,7 +6,8 @@
 
 <loader page-loader v-else-if="loading" />
 
-<div v-else-if="!canSeeFeedback" class="feedback-overview p-3 border rounded font-italic text-muted">
+<div v-else-if="!canSeeFeedback && !hasFeedback"
+     class="feedback-overview p-3 border rounded font-italic text-muted">
     The feedback is not yet available.
 </div>
 
@@ -138,13 +139,7 @@ export default {
         },
 
         feedback() {
-            const feedback = this.submission.feedback;
-
-            if (!feedback || !this.canSeeFeedback) {
-                return {};
-            }
-
-            return feedback;
+            return this.$utils.getProps(this.submission, {}, 'feedback');
         },
 
         fileIds() {
@@ -161,6 +156,16 @@ export default {
 
         submissionId() {
             return this.submission.id;
+        },
+
+        hasFeedback() {
+            if (this.feedback.general.length > 0) {
+                return true;
+            }
+            if (Object.keys(this.feedback.user).length > 0) {
+                return true;
+            }
+            return false;
         },
     },
 

--- a/src/components/FeedbackOverview.vue
+++ b/src/components/FeedbackOverview.vue
@@ -6,7 +6,7 @@
 
 <loader page-loader v-else-if="loading" />
 
-<div v-else-if="!canSeeFeedback && !hasFeedback"
+<div v-else-if="!feedbackAvailable"
      class="feedback-overview p-3 border rounded font-italic text-muted">
     The feedback is not yet available.
 </div>
@@ -159,13 +159,17 @@ export default {
         },
 
         hasFeedback() {
-            if (this.feedback.general.length > 0) {
+            if (this.feedback.general) {
                 return true;
             }
-            if (Object.keys(this.feedback.user).length > 0) {
+            if (!this.$utils.isEmpty(this.feedback.user)) {
                 return true;
             }
             return false;
+        },
+
+        feedbackAvailable() {
+            return this.canSeeFeedback || this.hasFeedback;
         },
     },
 


### PR DESCRIPTION
If you place a comment on your own submission as a student the badge of the feedback overview increments, however when you go to this overview the you are presented with the message "The feedback is not yet available.".

We used to determine when to show the message based on the permissions of a user, but now that students can place comments themselves they always have permission to see some comments. So now we always show feedback that we get back from the server, and only show the message when we've gotten nothing _and_ the student does not have permission to see feedback before the assignment is "done".

DEV-152 #done