### PR TITLE
Fix URL generation for getting more work

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -39,7 +39,8 @@ Version *Next*
   `(#1333) <https://github.com/CodeGra-de/CodeGra.de/pull/1333>`__,
   `(#1352) <https://github.com/CodeGra-de/CodeGra.de/pull/1352>`__,
   `(#1355) <https://github.com/CodeGra-de/CodeGra.de/pull/1355>`__,
-  `(#1356) <https://github.com/CodeGra-de/CodeGra.de/pull/1356>`__.
+  `(#1356) <https://github.com/CodeGra-de/CodeGra.de/pull/1356>`__,
+  `(#1360) <https://github.com/CodeGra-de/CodeGra.de/pull/1360>`__.
 
 Version LowVoltage
 -------------------

--- a/psef/auto_test/__init__.py
+++ b/psef/auto_test/__init__.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from multiprocessing import Event, Queue, context, managers
 
 import lxc  # typing: ignore
+import furl
 import urllib3
 import requests
 import structlog
@@ -1698,11 +1699,14 @@ class AutoTestRunner:
         )
 
     def _work_producer(self, last_call: bool) -> t.List[cg_worker_pool.Work]:
-        url = (
-            f'{self.base_url}/runs/{self.instructions["run_id"]}/'
-            f'results/?last_call={last_call}?limit={_get_amount_cpus() * 4}'
+        url = furl.furl(self.base_url).add(
+            path=['runs', self.instructions['run_id'], 'results', ''],
+            args={
+                'last_call': last_call,
+                'limit': _get_amount_cpus() * 4,
+            },
         )
-        res = self.req.get(url, timeout=_REQUEST_TIMEOUT)
+        res = self.req.get(str(url), timeout=_REQUEST_TIMEOUT)
         res.raise_for_status()
         return [cg_worker_pool.Work(**item) for item in res.json()]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ Flask-Migrate==2.5.3
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.1
 freezegun==0.3.15
+furl==2.1.0
 git+http://github.com/CodeGra-de/python3-lxc.git
 git+https://github.com/i-kiwamu/python3-oauth2.git
 git+https://github.com/libre-man/HTTPdomain#subdirectory=httpdomain


### PR DESCRIPTION
The url query was invalid (it used a ? instead of a &). We now build the url
using `furl`, which ensures that it is always exactly as wanted.