### PR TITLE
Fix ipython execute_result output

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -6,6 +6,11 @@ Version *Next*
 
 **Released**: TBD
 
+**Fixes**
+
+- Fix IPython ``execute_result`` cell outputs `(#1367)
+  <https://github.com/CodeGra-de/CodeGra.de>`__.
+
 Version *LowVoltage.1*
 ----------------------
 

--- a/src/components/InnerIPythonViewer.vue
+++ b/src/components/InnerIPythonViewer.vue
@@ -79,8 +79,8 @@
                                     <b style="color: red;">Unsupported output</b>
                                 </span>
                             </span>
-                            <pre v-else-if="out.output_type === 'stream'">{{ out.text }}</pre>
-                            <pre v-else-if="out.output_type === 'error'">{{ out.traceback.join("\n") }}</pre>
+                            <pre v-else-if="out.output_type === 'stream'">{{ maybeJoinArray(out.text) }}</pre>
+                            <pre v-else-if="out.output_type === 'error'">{{ maybeJoinArray(out.traceback) }}</pre>
                             <span v-else style="color: red;">
                                 <b>Unknown output type:</b> {{ out.output_type }}
                             </span>
@@ -153,10 +153,17 @@ export default {
                 // but instead has those keys directly on the output object.
                 const data = this.$utils.getProps(output, output, 'data');
                 if (data[types[i]]) {
-                    return data[types[i]];
+                    return this.maybeJoinArray(data[types[i]]);
                 }
             }
             return null;
+        },
+
+        maybeJoinArray(inp) {
+            if (Array.isArray(txt)) {
+                return txt.join('');
+            }
+            return txt;
         },
     },
 

--- a/src/components/InnerIPythonViewer.vue
+++ b/src/components/InnerIPythonViewer.vue
@@ -73,7 +73,7 @@
                                                            :show-code-whitespace="showWhitespace"/>
                                 </span>
                                 <span v-else-if="outputData(out, ['text', 'text/plain'])">
-                                    <pre>{{ outputData(out, ["text", "text/plain"]).join('') }}</pre>
+                                    <pre>{{ outputData(out, ['text', 'text/plain']) }}</pre>
                                 </span>
                                 <span v-else>
                                     <b style="color: red;">Unsupported output</b>

--- a/src/components/InnerIPythonViewer.vue
+++ b/src/components/InnerIPythonViewer.vue
@@ -159,7 +159,7 @@ export default {
             return null;
         },
 
-        maybeJoinArray(inp) {
+        maybeJoinArray(txt) {
             if (Array.isArray(txt)) {
                 return txt.join('');
             }

--- a/src/utils/ipython.ts
+++ b/src/utils/ipython.ts
@@ -144,7 +144,8 @@ export function getOutputCells(
                             text: undefined,
                         };
                         if (out.text != null) {
-                            // The `?? ''` case can never happen...
+                            // The `?? ''` case can never happen but is
+                            // necessary for Typescript.
                             newOut.text = maybeJoinText(out.text ?? '');
                         }
                     }

--- a/src/utils/ipython.ts
+++ b/src/utils/ipython.ts
@@ -26,6 +26,7 @@ type IPythonCodeCell = IPythonBaseCell & {
     outputs: (
         | {
               output_type?: Exclude<'stream', string>;
+              text?: string | string[];
           }
         | {
               output_type: 'stream';
@@ -54,6 +55,7 @@ type CGIPythonCodeCellOutput =
     | {
           output_type?: Exclude<'stream', string>;
           feedback_offset: number;
+          text?: string;
       }
     | {
           feedback_offset: number;
@@ -139,7 +141,12 @@ export function getOutputCells(
                         newOut = {
                             ...out,
                             feedback_offset: curOffset,
+                            text: undefined,
                         };
+                        if (out.text != null) {
+                            // The `?? ''` case can never happen...
+                            newOut.text = maybeJoinText(out.text ?? '');
+                        }
                     }
                     curOffset += 1;
                     return processOther(newOut);

--- a/test/unit/specs/IPythonViewer.spec.js
+++ b/test/unit/specs/IPythonViewer.spec.js
@@ -226,7 +226,7 @@ describe('IPythonViewer.vue', () => {
                         },
                         {
                             output_type: 'not stream',
-                            text: ['hello'],
+                            text: 'hello',
                             feedback_offset: 6,
                         },
                     ],
@@ -247,8 +247,7 @@ describe('IPythonViewer.vue', () => {
                         input: ['hello'],
                     },
                     {
-                        cell_type: 'code',
-                        input: ['import os\n\n\nprint(os.path.join(', 'a, b))'],
+                        cell_type: 'code', input: ['import os\n\n\nprint(os.path.join(', 'a, b))'],
                         outputs: [
                             {
                                 output_type: 'stream',
@@ -281,7 +280,7 @@ describe('IPythonViewer.vue', () => {
                         },
                         {
                             output_type: 'not stream',
-                            text: ['hello'],
+                            text: 'hello',
                             feedback_offset: 6,
                         },
                     ],
@@ -303,6 +302,60 @@ describe('IPythonViewer.vue', () => {
             expect(comp.$emit).lastCalledWith('error', err);
             expect(err.error).toBeInstanceOf(Error);
             expect(err.error.message).toMatch('Only Jupyter Notebook format v3 or greater is supported.');
+        });
+
+        it('should accept strings and lists of strings as output text', async () => {
+            await setData(JSON.stringify({
+                nbformat: 4,
+                metadata: {
+                    language_info: { name: 'python' },
+                },
+                cells: [
+                    {
+                        cell_type: 'code',
+                        input: ['import os\n\n\nprint(os.path.join(', 'a, b))'],
+                        outputs: [
+                            {
+                                output_type: 'execute_result',
+                                text: ['line1\n', 'line2\n'],
+                            },
+                            {
+                                output_type: 'execute_result',
+                                text: 'line1\nline2\n',
+                            },
+                            {
+                                output_type: 'not stream',
+                                text: 'line1\nline2\n',
+                            },
+                        ],
+                    },
+                ],
+            }));
+            expect(comp.data).not.toEqual({});
+            expect(comp.outputCells).toMatchObject([
+                {
+                    cell_type: 'code',
+                    source: ['import os', '', '', 'print(os.path.join(a, b))'],
+                    feedback_offset: 0,
+                    outputs: [
+                        {
+                            output_type: 'execute_result',
+                            text: 'line1\nline2\n',
+                            feedback_offset: 4
+                        },
+                        {
+                            output_type: 'execute_result',
+                            text: 'line1\nline2\n',
+                            feedback_offset: 5,
+                        },
+                        {
+                            output_type: 'not stream',
+                            text: 'line1\nline2\n',
+                            feedback_offset: 6,
+                        },
+                    ],
+                },
+            ]);
         });
     });
 


### PR DESCRIPTION
We received an error that `join` is not a method on the output text of
an execute_result cell output. We always expected it to be a list of
strings, but it turns out that it is also sometimes just a string.