### PR TITLE
DEV-169 Improve student buttons on submissions page

### DIFF
--- a/src/pages/Submissions.vue
+++ b/src/pages/Submissions.vue
@@ -918,13 +918,19 @@ export default {
     flex: 0 0 ~'calc(33.33% - 2rem)';
     height: 12rem;
 
+    @media @media-no-large {
+        flex-basis: ~'calc(40% - 2rem)';
+        min-width: 14rem;
+    }
+
     @media @media-small {
         flex-basis: ~'calc(50% - 1rem)';
         height: 10rem;
+        min-width: 10rem;
     }
 
-    @media (max-width: 17.5rem) {
-        flex-basis: ~'calc(100% - 1rem)';
+    @media (max-width: 24rem) {
+        flex-grow: 1;
     }
 
     &.variant-danger {


### PR DESCRIPTION
On a medium screen we would try to fit 3 buttons next to each other, but
this wasn't giving them enough space to render their labels on a single
line on screens just a bit larger than small screens. This makes the
buttons 40% of the available width, up to a minimum size that leaves
them enough space to draw their labels on a single line.

Before

![medium-old](https://user-images.githubusercontent.com/3612514/84502794-484aa480-acb9-11ea-8508-58ce586eb3a4.png)

After

![medium-new](https://user-images.githubusercontent.com/3612514/84502804-4d0f5880-acb9-11ea-8637-521d3e8d6d03.png)

DEV-169 #done