### PR TITLE
[DEV-220] Make it possible to add tests for migrations

### DIFF
--- a/.github/scripts/run_backend_tests.bash
+++ b/.github/scripts/run_backend_tests.bash
@@ -47,6 +47,10 @@ sudo chown -R "$USER":"$(id -gn "$USER")" "$(npm root -g)"
 sudo chown -R "$USER":"$(id -gn "$USER")" ~/.config
 
 export BASE_DATABASE_URI='postgresql://postgres:postgres@localhost:5432/ci_test_'
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5432
+export POSTGRES_USERNAME=postgres
+export PGPASSWORD=postgres
 
 pytest --cov cg_worker_pool \
        --cov cg_threading_utils \

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,8 +1,15 @@
 from __future__ import with_statement
-from alembic import context
-from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig
+
 import logging
+from logging.config import fileConfig
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from flask import current_app
+from alembic import context
+from sqlalchemy import pool, engine_from_config
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -13,13 +20,10 @@ config = context.config
 fileConfig(config.config_file_name)
 logger = logging.getLogger('alembic.env')
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-from flask import current_app
-config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+if config.get_main_option('sqlalchemy.url', None) is None:
+    config.set_main_option('sqlalchemy.url',
+                           current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+    assert current_app
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -3,10 +3,6 @@ from __future__ import with_statement
 import logging
 from logging.config import fileConfig
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
 from flask import current_app
 from alembic import context
 from sqlalchemy import pool, engine_from_config
@@ -23,7 +19,6 @@ logger = logging.getLogger('alembic.env')
 if config.get_main_option('sqlalchemy.url', None) is None:
     config.set_main_option('sqlalchemy.url',
                            current_app.config.get('SQLALCHEMY_DATABASE_URI'))
-    assert current_app
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/psef_test/conftest.py
+++ b/psef_test/conftest.py
@@ -142,6 +142,10 @@ def make_app_settings(request):
             'AUTO_TEST_DISABLE_ORIGIN_CHECK': True,
             'AUTO_TEST_MAX_TIME_COMMAND': 3,
             'ADMIN_USER': None,
+            'CELERY_CONFIG': {
+                'CELERY_TASK_ALWAYS_EAGER': True,
+                'CELERY_TASK_EAGER_PROPAGATES': True,
+            },
         }
         if database is not None:
             settings_override['SQLALCHEMY_DATABASE_URI'] = database
@@ -153,11 +157,6 @@ def make_app_settings(request):
         else:
             settings_override['SQLALCHEMY_DATABASE_URI'] = TEST_DATABASE_URI
             settings_override['_USING_SQLITE'] = True
-
-        settings_override['CELERY_CONFIG'] = {
-            'CELERY_TASK_ALWAYS_EAGER': True,
-            'CELERY_TASK_EAGER_PROPAGATES': True,
-        }
 
         return settings_override
 

--- a/psef_test/conftest.py
+++ b/psef_test/conftest.py
@@ -111,7 +111,9 @@ def make_app_settings(request):
                 "java",
                 "-Dbasedir={files}",
                 "-jar",
-                os.path.join(os.path.dirname(__file__), '..', 'checkstyle.jar'),
+                os.path.join(
+                    os.path.dirname(__file__), '..', 'checkstyle.jar'
+                ),
                 "-f",
                 "xml",
                 "-c",
@@ -119,7 +121,9 @@ def make_app_settings(request):
                 "{files}",
             ],
             'PMD_PROGRAM': [
-                os.path.join(os.path.dirname(__file__), '..', './pmd/bin/run.sh'),
+                os.path.join(
+                    os.path.dirname(__file__), '..', './pmd/bin/run.sh'
+                ),
                 'pmd',
                 '-dir',
                 '{files}',
@@ -158,6 +162,7 @@ def make_app_settings(request):
         return settings_override
 
     yield inner
+
 
 @pytest.fixture(scope='session')
 def app(request, make_app_settings):

--- a/psef_test/migrations/__init__.py
+++ b/psef_test/migrations/__init__.py
@@ -4,7 +4,6 @@ import abc
 class Tester(abc.ABC):
     def __init__(self, db, **_):
         self.db = db
-        self.users = None
 
     @staticmethod
     def do_test():

--- a/psef_test/migrations/__init__.py
+++ b/psef_test/migrations/__init__.py
@@ -1,0 +1,19 @@
+import abc
+
+
+class Tester(abc.ABC):
+    def __init__(self, db, **_):
+        self.db = db
+        self.users = None
+
+    @staticmethod
+    def do_test():
+        return True
+
+    @abc.abstractmethod
+    def load_data(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def check(self):
+        raise NotImplementedError

--- a/psef_test/migrations/migration_bef732f2f4ac/__init__.py
+++ b/psef_test/migrations/migration_bef732f2f4ac/__init__.py
@@ -3,16 +3,13 @@ from itertools import groupby
 
 import pytest
 
+from .. import Tester
 
-class UpgradeTester:
-    def __init__(self, db, **_):
-        self.db = db
-        self.users = None
 
+class UpgradeTester(Tester):
     def get_users(self):
         return self.db.engine.execute('SELECT * FROM "User" ORDER BY id'
                                       ).fetchall()
-
     @staticmethod
     def do_test():
         return True
@@ -20,7 +17,7 @@ class UpgradeTester:
     def load_data(self):
         self.users = self.get_users()
 
-    def check_upgrade(self):
+    def check(self):
         cur_users = self.get_users()
         assert len(cur_users) > 0
         assert len(self.users) == len(cur_users), 'No users should be deleted'
@@ -40,7 +37,6 @@ class UpgradeTester:
                 lambda el: el.user_id,
             )
         }
-        print(user_lti_provider_connections)
 
         # User 5 was not an LTI user
         assert set(user_lti_provider_connections.keys()) == {1, 2, 3, 4, 6}
@@ -65,10 +61,7 @@ class UpgradeTester:
         check_connections(6, ['lti_prov_2'], '66')
 
 
-class DowngradeTester:
-    def __init__(self, db, **_):
-        self.db = db
-
+class DowngradeTester(Tester):
     @staticmethod
     def do_test():
         return False
@@ -76,5 +69,5 @@ class DowngradeTester:
     def load_data(self):
         pass
 
-    def check_downgrade(self):
+    def check(self):
         pass

--- a/psef_test/migrations/migration_bef732f2f4ac/__init__.py
+++ b/psef_test/migrations/migration_bef732f2f4ac/__init__.py
@@ -1,0 +1,80 @@
+import subprocess
+from itertools import groupby
+
+import pytest
+
+
+class UpgradeTester:
+    def __init__(self, db, **_):
+        self.db = db
+        self.users = None
+
+    def get_users(self):
+        return self.db.engine.execute('SELECT * FROM "User" ORDER BY id'
+                                      ).fetchall()
+
+    @staticmethod
+    def do_test():
+        return True
+
+    def load_data(self):
+        self.users = self.get_users()
+
+    def check_upgrade(self):
+        cur_users = self.get_users()
+        assert len(cur_users) > 0
+        assert len(self.users) == len(cur_users), 'No users should be deleted'
+
+        for cur_user, old_user in zip(cur_users, self.users):
+            assert cur_user.id == old_user.id
+            assert cur_user.username == old_user.username
+            assert hasattr(old_user, 'lti_user_id')
+            assert not hasattr(cur_user, 'lti_user_id')
+
+        user_lti_provider_connections = {
+            k: list(v)
+            for k, v in groupby(
+                self.db.engine.execute(
+                    'SELECT * FROM "user_lti-provider" ORDER BY user_id'
+                ).fetchall(),
+                lambda el: el.user_id,
+            )
+        }
+        print(user_lti_provider_connections)
+
+        # User 5 was not an LTI user
+        assert set(user_lti_provider_connections.keys()) == {1, 2, 3, 4, 6}
+
+        def check_connections(user_id, wanted_ids, lti_user_id):
+            found = [
+                c.lti_provider_id
+                for c in user_lti_provider_connections[user_id]
+            ]
+            found_set = set(found)
+            assert len(found) == len(found_set)
+            assert found_set == set(wanted_ids)
+            assert all(
+                c.lti_user_id == lti_user_id
+                for c in user_lti_provider_connections[user_id]
+            )
+
+        check_connections(1, ['lti_prov_1', 'lti_prov_2'], '11')
+        check_connections(2, ['lti_prov_1'], '22')
+        check_connections(3, ['lti_prov_1', 'lti_prov_2'], '33')
+        check_connections(4, ['lti_prov_1'], '44')
+        check_connections(6, ['lti_prov_2'], '66')
+
+
+class DowngradeTester:
+    def __init__(self, db, **_):
+        self.db = db
+
+    @staticmethod
+    def do_test():
+        return False
+
+    def load_data(self):
+        pass
+
+    def check_downgrade(self):
+        pass

--- a/psef_test/migrations/migration_bef732f2f4ac/__init__.py
+++ b/psef_test/migrations/migration_bef732f2f4ac/__init__.py
@@ -10,6 +10,7 @@ class UpgradeTester(Tester):
     def get_users(self):
         return self.db.engine.execute('SELECT * FROM "User" ORDER BY id'
                                       ).fetchall()
+
     @staticmethod
     def do_test():
         return True

--- a/psef_test/migrations/migration_bef732f2f4ac/setup_upgrade.sql
+++ b/psef_test/migrations/migration_bef732f2f4ac/setup_upgrade.sql
@@ -1,0 +1,58 @@
+/* -*- mode: sql; sql-product: postgres; -*- */
+INSERT INTO "User" (id,
+                    username,
+                    email,
+                    name,
+                    lti_user_id)
+VALUES (1, 'user1', 'email1', 'User 1', 11),
+       (2, 'user2', 'email2', 'User 2', 22),
+       (3, 'user3', 'email3', 'User 3', 33),
+       (4, 'user4', 'email4', 'User 4', 44),
+       (5, 'user5', 'email5', 'User 5', NULL),
+       (6, 'user6', 'email6', 'User 6', 66);
+
+
+INSERT INTO "LTIProvider" (id,
+                           key)
+VALUES ('lti_prov_1', 'key_1'),
+       ('lti_prov_2', 'key_2');
+
+
+INSERT INTO "Course" (id,
+                      name,
+                      lti_provider_id,
+                      lti_course_id)
+VALUES (1, 'course 1', 'lti_prov_1', 'lti_course_1'),
+       (2, 'course 2', 'lti_prov_1', 'lti_course_2'),
+       (3, 'course 3', 'lti_prov_2', 'lti_course_3'),
+       (4, 'non lti course', NULL, NULL);
+
+
+INSERT INTO "Course_Role" (id,
+                           name,
+                           "Course_id")
+VALUES (1, 'cr1_1', 1),
+       (2, 'cr2_1', 1),
+       (3, 'cr3_1', 1),
+       (4, 'cr4_1', 1),
+       (5, 'cr1_2', 2),
+       (6, 'cr2_2', 2),
+       (7, 'cr3_2', 2),
+       (8, 'cr4_2', 2),
+       (9, 'cr1_3', 3),
+       (10, 'cr2_3', 3),
+       (11, 'cr3_3', 3),
+       (12, 'cr4_3', 3),
+       (13, 'cr1_4', 4);
+
+
+INSERT INTO "users-courses" (user_id,
+                            course_id)
+VALUES (1, 1),
+       (1, 12),
+       (2, 7),
+       (3, 11),
+       (3, 2),
+       (4, 6),
+       (5, 13),
+       (6, 12);

--- a/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
@@ -1,0 +1,74 @@
+import subprocess
+from itertools import groupby
+
+import pytest
+
+
+def test_connections(conn_by_id, new_style_courses, old_style_courses):
+   for cur_course, old_course in zip(new_style_courses, old_style_courses):
+       assert cur_course.id == old_course.id
+       if old_course.lti_provider_id is None:
+           assert cur_course.id not in conn_by_id
+       else:
+           assert cur_course.id in conn_by_id
+           conn = conn_by_id[cur_course.id]
+           assert conn.id is not None
+           assert conn.lti_provider_id == old_course.lti_provider_id
+           assert conn.lti_course_id == old_course.lti_course_id
+           assert conn.deployment_id == old_course.lti_course_id
+
+
+class UpgradeTester:
+    def __init__(self, db, **_):
+        self.db = db
+        self.courses = None
+
+    def get_courses(self):
+        return self.db.engine.execute('SELECT * FROM "Course" ORDER BY id'
+                                      ).fetchall()
+
+    @staticmethod
+    def do_test():
+        return True
+
+    def load_data(self):
+        self.courses = self.get_courses()
+
+    def check_upgrade(self):
+        cur_courses = self.get_courses()
+        assert len(cur_courses) > 0
+        assert len(self.courses
+                   ) == len(cur_courses), 'No courses should be deleted'
+
+        test_connections(conn_by_id, cur_courses, self.courses)
+
+
+class DowngradeTester:
+    def __init__(self, db, **_):
+        self.db = db
+        self.courses = None
+        self.conn_by_id = None
+
+    def get_courses(self):
+        return self.db.engine.execute('SELECT * FROM "Course" ORDER BY id'
+                                      ).fetchall()
+
+    @staticmethod
+    def do_test():
+        return True
+
+    def load_data(self):
+        self.courses = self.get_courses()
+        connections = self.db.engine.execute(
+            'SELECT * FROM course_lti_provider ORDER BY course_id'
+        ).fetchall()
+        assert len(set(c.course_id for c in connections)) == len(connections)
+        self.conn_by_id = {c.course_id: c for c in connections}
+
+    def check_downgrade(self):
+        cur_courses = self.get_courses()
+        assert len(cur_courses) > 0
+        assert len(self.courses
+                   ) == len(cur_courses), 'No courses should be deleted'
+
+        test_connections(self.conn_by_id, self.courses, cur_courses)

--- a/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
@@ -40,6 +40,11 @@ class UpgradeTester:
         assert len(self.courses
                    ) == len(cur_courses), 'No courses should be deleted'
 
+        connections = self.db.engine.execute(
+            'SELECT * FROM course_lti_provider ORDER BY course_id'
+        ).fetchall()
+        assert len(set(c.course_id for c in connections)) == len(connections)
+        conn_by_id = {c.course_id: c for c in connections}
         test_connections(conn_by_id, cur_courses, self.courses)
 
 

--- a/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
@@ -3,6 +3,8 @@ from itertools import groupby
 
 import pytest
 
+from .. import Tester
+
 
 def test_connections(conn_by_id, new_style_courses, old_style_courses):
     for cur_course, old_course in zip(new_style_courses, old_style_courses):
@@ -18,23 +20,17 @@ def test_connections(conn_by_id, new_style_courses, old_style_courses):
             assert conn.deployment_id == old_course.lti_course_id
 
 
-class UpgradeTester:
-    def __init__(self, db, **_):
-        self.db = db
-        self.courses = None
+class UpgradeTester(Tester):
+    courses = None
 
     def get_courses(self):
         return self.db.engine.execute('SELECT * FROM "Course" ORDER BY id'
                                       ).fetchall()
 
-    @staticmethod
-    def do_test():
-        return True
-
     def load_data(self):
         self.courses = self.get_courses()
 
-    def check_upgrade(self):
+    def check(self):
         cur_courses = self.get_courses()
         assert len(cur_courses) > 0
         assert len(self.courses
@@ -48,19 +44,13 @@ class UpgradeTester:
         test_connections(conn_by_id, cur_courses, self.courses)
 
 
-class DowngradeTester:
-    def __init__(self, db, **_):
-        self.db = db
-        self.courses = None
-        self.conn_by_id = None
+class DowngradeTester(Tester):
+    courses = None
+    conn_by_id = None
 
     def get_courses(self):
         return self.db.engine.execute('SELECT * FROM "Course" ORDER BY id'
                                       ).fetchall()
-
-    @staticmethod
-    def do_test():
-        return True
 
     def load_data(self):
         self.courses = self.get_courses()
@@ -70,7 +60,7 @@ class DowngradeTester:
         assert len(set(c.course_id for c in connections)) == len(connections)
         self.conn_by_id = {c.course_id: c for c in connections}
 
-    def check_downgrade(self):
+    def check(self):
         cur_courses = self.get_courses()
         assert len(cur_courses) > 0
         assert len(self.courses

--- a/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/__init__.py
@@ -5,17 +5,17 @@ import pytest
 
 
 def test_connections(conn_by_id, new_style_courses, old_style_courses):
-   for cur_course, old_course in zip(new_style_courses, old_style_courses):
-       assert cur_course.id == old_course.id
-       if old_course.lti_provider_id is None:
-           assert cur_course.id not in conn_by_id
-       else:
-           assert cur_course.id in conn_by_id
-           conn = conn_by_id[cur_course.id]
-           assert conn.id is not None
-           assert conn.lti_provider_id == old_course.lti_provider_id
-           assert conn.lti_course_id == old_course.lti_course_id
-           assert conn.deployment_id == old_course.lti_course_id
+    for cur_course, old_course in zip(new_style_courses, old_style_courses):
+        assert cur_course.id == old_course.id
+        if old_course.lti_provider_id is None:
+            assert cur_course.id not in conn_by_id
+        else:
+            assert cur_course.id in conn_by_id
+            conn = conn_by_id[cur_course.id]
+            assert conn.id is not None
+            assert conn.lti_provider_id == old_course.lti_provider_id
+            assert conn.lti_course_id == old_course.lti_course_id
+            assert conn.deployment_id == old_course.lti_course_id
 
 
 class UpgradeTester:

--- a/psef_test/migrations/migration_e9b4a9fe0b85/setup_downgrade.sql
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/setup_downgrade.sql
@@ -1,0 +1,18 @@
+INSERT INTO "LTIProvider" (id,
+                           key)
+VALUES ('lti_prov_1', 'key_1'),
+       ('lti_prov_2', 'key_2');
+
+
+INSERT INTO "Course" (id,
+                      name)
+VALUES (1, 'course 1'),
+       (2, 'course 2'),
+       (3, 'course 3'),
+       (4, 'non lti course');
+
+
+INSERT INTO course_lti_provider (id, created_at, updated_at, lti_course_id, deployment_id, lti_provider_id, course_id)
+VALUES (uuid_generate_v4(), NOW(), NOW(), 'lti_course_1', 'lti_course_1', 'lti_prov_1', 1),
+       (uuid_generate_v4(), NOW(), NOW(), 'lti_course_2', 'lti_course_2', 'lti_prov_1', 2),
+       (uuid_generate_v4(), NOW(), NOW(), 'lti_course_3', 'lti_course_3', 'lti_prov_2', 3);

--- a/psef_test/migrations/migration_e9b4a9fe0b85/setup_upgrade.sql
+++ b/psef_test/migrations/migration_e9b4a9fe0b85/setup_upgrade.sql
@@ -1,0 +1,15 @@
+/* -*- mode: sql; sql-product: postgres; -*- */
+INSERT INTO "LTIProvider" (id,
+                           key)
+VALUES ('lti_prov_1', 'key_1'),
+       ('lti_prov_2', 'key_2');
+
+
+INSERT INTO "Course" (id,
+                      name,
+                      lti_provider_id,
+                      lti_course_id)
+VALUES (1, 'course 1', 'lti_prov_1', 'lti_course_1'),
+       (2, 'course 2', 'lti_prov_1', 'lti_course_2'),
+       (3, 'course 3', 'lti_prov_2', 'lti_course_3'),
+       (4, 'non lti course', NULL, NULL);

--- a/psef_test/test_migrations.py
+++ b/psef_test/test_migrations.py
@@ -33,8 +33,8 @@ ALL_MIGRATIONS = [
 
 MIGRATIONS_TEST_DIR = path.join(path.dirname(__file__), 'migrations')
 ALL_MIGRATION_TESTS = [
-    x.split('.', 1)[0].split('_')[1] for x in os.listdir(MIGRATIONS_TEST_DIR)
-    if (
+    re.match(r'migration_([0-9a-f]+)(\.py)?', x).group(1)
+    for x in os.listdir(MIGRATIONS_TEST_DIR) if (
         x not in ('__init__.py', '__pycache__') and
         (x.endswith('.py') or path.isdir(path.join(MIGRATIONS_TEST_DIR, x)))
     )
@@ -130,7 +130,6 @@ def alembic_config(fresh_database):
 
 
 def list_migrations(alembic_config, head):
-    print(alembic_config)
     config = AlembicConfig(alembic_config)
     script = ScriptDirectory.from_config(config)
     migrations = [
@@ -196,7 +195,7 @@ def test_upgrade_with_data(
     upgrade(alembic_config, migration)
 
     # Make sure it applied "cleanly" for some definition of clean
-    upgrade_tester.check_upgrade()
+    upgrade_tester.check()
 
 
 @pytest.mark.parametrize('migration', ALL_TESTED_MIGRATIONS)
@@ -230,4 +229,4 @@ def test_downgrade_with_data(
     downgrade(alembic_config, '-1')
 
     # Make sure it applied "cleanly" for some definition of clean
-    downgrade_tester.check_downgrade()
+    downgrade_tester.check()

--- a/psef_test/test_migrations.py
+++ b/psef_test/test_migrations.py
@@ -160,7 +160,7 @@ def test_upgrade_with_data(
     setup_sql = path.join(
         MIGRATIONS_TEST_DIR, f'migration_{migration}', 'setup_upgrade.sql'
     )
-    if path.isfile(setup_sql):
+    if path.isfile(setup_sql) or path.islink(setup_sql):
         subprocess.check_call(
             [
                 'psql', '-d', fresh_database.db_name, '--set=ON_ERROR_STOP=1',
@@ -195,9 +195,9 @@ def test_downgrade_with_data(
 
     # Load the test data
     setup_sql = path.join(
-        MIGRATIONS_TEST_DIR, f'migration_{migration}', 'setup_downgade.sql'
+        MIGRATIONS_TEST_DIR, f'migration_{migration}', 'setup_downgrade.sql'
     )
-    if path.isfile(setup_sql):
+    if path.isfile(setup_sql) or path.islink(setup_sql):
         subprocess.check_call(
             [
                 'psql', '-d', fresh_database.db_name, '--set=ON_ERROR_STOP=1',

--- a/psef_test/test_migrations.py
+++ b/psef_test/test_migrations.py
@@ -1,0 +1,275 @@
+import os
+import re
+import uuid
+import tempfile
+import subprocess
+import configparser
+from os import path
+from collections import namedtuple
+
+import pytest
+import alembic
+from sqlalchemy import text, create_engine
+from flask_migrate import Migrate
+from alembic.config import Config as AlembicConfig
+from alembic.script import ScriptDirectory
+
+import psef
+import migrations
+
+MIGRATION_PATH = path.join(path.dirname(__file__), '..', 'migrations')
+
+ALL_MIGRATIONS = [
+    x.split('.', 1)[0].split('_', 1)[0]
+    for x in os.listdir(path.join(MIGRATION_PATH, 'versions'))
+    if x.endswith('.py')
+]
+
+MIGRATIONS_TEST_DIR = path.join(path.dirname(__file__), 'migrations')
+ALL_MIGRATION_TESTS = [
+    x.split('.', 1)[0].split('_')[1] for x in os.listdir(MIGRATIONS_TEST_DIR)
+    if (
+        x not in ('__init__.py', '__pycache__') and
+        (x.endswith('.py') or path.isdir(path.join(MIGRATIONS_TEST_DIR, x)))
+    )
+]
+assert ALL_MIGRATION_TESTS
+
+ALL_TESTED_MIGRATIONS = []
+
+
+def fill_all_tested_migrations():
+    for migration in ALL_MIGRATIONS:
+        if migration in ALL_MIGRATION_TESTS:
+            ALL_TESTED_MIGRATIONS.append(migration)
+            ALL_MIGRATION_TESTS.remove(migration)
+            # Make sure pytest rewrites the assertions in these test files
+            mod_name = 'migrations.migration_{}'.format(migration)
+            pytest.register_assert_rewrite(mod_name)
+
+
+fill_all_tested_migrations()
+assert not ALL_MIGRATION_TESTS, 'Found unknown migrations'
+assert ALL_TESTED_MIGRATIONS
+
+WHITESPACE_REGEX = re.compile(r'\s+')
+FreshDatabase = namedtuple('FreshDatabase', ['engine', 'name', 'db_name'])
+
+
+@pytest.fixture
+def migration_app(make_app_settings, fresh_database):
+    app = psef.create_app(
+        make_app_settings(database=fresh_database.name),
+        skip_celery=True,
+        skip_perm_check=True
+    )
+    Migrate(app, psef.models.db, compare_type=True)
+    yield app
+
+
+@pytest.fixture
+def fresh_database():
+    db_name = f'migration_test_db_{uuid.uuid4()}'.replace('-', '')
+    subprocess.check_output(['psql', '-c', f'create database "{db_name}"'])
+    try:
+        subprocess.check_output([
+            'psql', db_name, '-c', 'create extension "uuid-ossp"'
+        ])
+        subprocess.check_output([
+            'psql', db_name, '-c', 'create extension "citext"'
+        ])
+        db_string = f'postgresql:///{db_name}'
+        engine = create_engine(db_string)
+        yield FreshDatabase(engine=engine, name=db_string, db_name=db_name)
+    finally:
+        engine.dispose()
+        subprocess.check_output(['psql', '-c', f'drop database "{db_name}"'])
+
+
+@pytest.fixture
+def alembic_config(fresh_database):
+    ini = configparser.ConfigParser()
+    ini.read(path.join(MIGRATION_PATH, 'alembic.ini'))
+    ini.set('alembic', 'script_location', path.join(MIGRATION_PATH))
+    ini.set('alembic', 'sqlalchemy.url', fresh_database.name)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        res = path.join(tmp_dir, 'alembic.ini')
+        with open(res, 'w') as f:
+            ini.write(f)
+        yield res
+
+
+def list_migrations(alembic_config, head):
+    print(alembic_config)
+    config = AlembicConfig(alembic_config)
+    script = ScriptDirectory.from_config(config)
+    migrations = [
+        x.revision for x in script.walk_revisions(base='base', head=head)
+    ]
+    migrations.reverse()
+    return migrations
+
+
+@pytest.fixture
+def upgrade(migration_app):
+    def inner(alembic_config, migration):
+        with migration_app.app_context():
+            config = AlembicConfig(alembic_config)
+            alembic.command.upgrade(config, migration, sql=False, tag=None)
+
+    yield inner
+
+
+@pytest.fixture
+def downgrade(migration_app):
+    def inner(alembic_config, migration):
+        with migration_app.app_context():
+            config = AlembicConfig(alembic_config)
+            alembic.command.downgrade(config, migration, sql=False, tag=None)
+
+    yield inner
+
+
+def get_schema(app, db):
+    with app.app_context():
+        result = list(
+            db.engine.execute(
+                text(
+                    '''
+            SELECT type, name, tbl_name, sql
+            FROM sqlite_master
+            ORDER BY type, name, tbl_name
+            '''
+                )
+            )
+        )
+
+    return {(x[0], x[1], x[2]): x[3] for x in result}
+
+
+def assert_schemas_equal(left, right):
+    for k, v in left.items():
+        if k not in right:
+            raise AssertionError(
+                'Left contained {} but right did not'.format(k)
+            )
+        if not ddl_equal(v, right[k]):
+            raise AssertionError(
+                'Schema for {} did not match:\nLeft:\n{}\nRight:\n{}'.format(
+                    k, v, right[k]
+                )
+            )
+        right.pop(k)
+
+    if right:
+        raise AssertionError(
+            'Right had additional tables: {}'.format(list(right.keys()))
+        )
+
+
+def ddl_equal(left, right):
+    '''Check the "tokenized" DDL is equivalent because, because sometimes
+        Alembic schemas append columns on the same line to the DDL comes out
+        like:
+
+        column1 TEXT NOT NULL, column2 TEXT NOT NULL
+
+        and SQLAlchemy comes out:
+
+        column1 TEXT NOT NULL,
+        column2 TEXT NOT NULL
+    '''
+    # ignore the autoindex cases
+    if left is None and right is None:
+        return True
+
+    left = [x for x in WHITESPACE_REGEX.split(left) if x]
+    right = [x for x in WHITESPACE_REGEX.split(right) if x]
+
+    # Strip commas and quotes
+    left = [x.replace("\"", "").replace(",", "") for x in left]
+    right = [x.replace("\"", "").replace(",", "") for x in right]
+
+    return sorted(left) == sorted(right)
+
+
+@pytest.mark.parametrize('migration', ALL_TESTED_MIGRATIONS)
+def test_upgrade_with_data(
+    alembic_config, migration, fresh_database, migration_app, upgrade
+):
+    migrations = list_migrations(alembic_config, migration)
+    if len(migrations) == 1:
+        # Degenerate case where there is no data for the first migration
+        return
+
+    # Upgrade to one migration before the target stored in `migration`
+    last_migration = migrations[-2]
+    upgrade(alembic_config, last_migration)
+
+    # Dynamic module import
+    mod_name = 'migrations.migration_{}'.format(migration)
+    mod = __import__(mod_name, fromlist=['UpgradeTester'])
+    if not mod.UpgradeTester.do_test():
+        pytest.skip('This upgrade is not tested')
+
+    # Load the test data
+    setup_sql = path.join(
+        MIGRATIONS_TEST_DIR, f'migration_{migration}', 'setup_upgrade.sql'
+    )
+    if path.isfile(setup_sql):
+        subprocess.check_call(
+            [
+                'psql', '-d', fresh_database.db_name, '--set=ON_ERROR_STOP=1',
+                '--set=ECHO=queries', '-f', setup_sql
+            ],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    upgrade_tester = mod.UpgradeTester(db=fresh_database)
+    upgrade_tester.load_data()
+
+    # Upgrade to the target
+    upgrade(alembic_config, migration)
+
+    # Make sure it applied "cleanly" for some definition of clean
+    upgrade_tester.check_upgrade()
+
+
+@pytest.mark.parametrize('migration', ALL_TESTED_MIGRATIONS)
+def test_downgrade_with_data(
+    alembic_config, migration, fresh_database, downgrade, upgrade
+):
+    # Upgrade to the target
+    upgrade(alembic_config, migration)
+
+    # Dynamic module import
+    mod_name = 'migrations.migration_{}'.format(migration)
+    mod = __import__(mod_name, fromlist=['DowngradeTester'])
+    if not mod.DowngradeTester.do_test():
+        pytest.skip('This upgrade is not tested')
+
+    # Load the test data
+    setup_sql = path.join(
+        MIGRATIONS_TEST_DIR, f'migration_{migration}', 'setup_downgade.sql'
+    )
+    if path.isfile(setup_sql):
+        subprocess.check_call(
+            [
+                'psql', '-d', fresh_database.db_name, '--set=ON_ERROR_STOP=1',
+                '--set=ECHO=queries', '-f', setup_sql
+            ],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    # Load the test data
+    downgrade_tester = mod.DowngradeTester(db=fresh_database)
+    downgrade_tester.load_data()
+
+    # Downgrade to previous migration
+    downgrade(alembic_config, '-1')
+
+    # Make sure it applied "cleanly" for some definition of clean
+    downgrade_tester.check_downgrade()


### PR DESCRIPTION
You can add tests by adding a new file in the `psef_test/migrations/` directory. This test can either be a directory or a simple python file. If imported the module/file should expose two classes `TestUpgrade` and `TestDowngrade`. Each class has to define some methods, see the committed migration test as example. If it is a directory the directory can also contain `setup_upgrade.sql` and `setup_downgrade.sql` which will be executed before respectively the upgrade and downgrade tests.

!ignore changelog

DEV-220 #finished