### PR TITLE
DEV-146 Use rubric rows from the store in AutoTestSuite

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -9,7 +9,9 @@ Version *Next*
 **Fixes**
 
 - Fix IPython ``execute_result`` cell outputs `(#1367)
-  <https://github.com/CodeGra-de/CodeGra.de>`__.
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1367>`__.
+- Miscellaneous fixes:
+  `(#1373) <https://github.com/CodeGra-de/CodeGra.de/pull/1373>`__.
 
 Version *LowVoltage.1*
 ----------------------

--- a/src/components/AutoTestSuite.vue
+++ b/src/components/AutoTestSuite.vue
@@ -230,11 +230,11 @@
             <span class="title">
                 <a v-if="result"
                    href="#"
-                   @click.capture.prevent.stop="$root.$emit('cg::rubric-viewer::open-category', value.rubricRow.id)">
-                    {{ value.rubricRow.header }}
+                   @click.capture.prevent.stop="$root.$emit('cg::rubric-viewer::open-category', rubricRow.id)">
+                    {{ rubricRow.header }}
                 </a>
                 <template v-else>
-                    {{ value.rubricRow.header }}
+                    {{ rubricRow.header }}
                 </template>
             </span>
 
@@ -453,7 +453,12 @@ export default {
         },
 
         rubricRow() {
-            return getProps(this, null, 'internalValue', 'rubricRow');
+            const value = this.internalValue || this.value;
+            const rowId = getProps(value, null, 'rubricRow', 'id');
+            if (rowId == null) {
+                return null;
+            }
+            return getProps(this.rubric, null, 'rowsById', rowId);
         },
 
         pointPercentage() {

--- a/src/components/AutoTestSuite.vue
+++ b/src/components/AutoTestSuite.vue
@@ -343,6 +343,7 @@ import 'vue-awesome/icons/minus-square';
 import 'vue-awesome/icons/plus-square';
 import 'vue-awesome/icons/caret-down';
 
+import { Assignment, AutoTestSuiteData, AutoTestResult } from '@/models';
 import { getProps } from '@/utils';
 
 import Collapse from './Collapse';
@@ -354,11 +355,11 @@ export default {
 
     props: {
         value: {
-            type: Object,
+            type: AutoTestSuiteData,
             required: true,
         },
         assignment: {
-            type: Object,
+            type: Assignment,
             required: true,
         },
         otherSuites: {
@@ -374,7 +375,7 @@ export default {
             default: false,
         },
         result: {
-            type: Object,
+            type: AutoTestResult,
             default: null,
         },
     },
@@ -458,8 +459,7 @@ export default {
         },
 
         rubricRow() {
-            const value = this.internalValue || this.value;
-            const rowId = getProps(value, null, 'rubricRow', 'id');
+            const rowId = getProps(this.value, null, 'rubricRow', 'id');
             if (rowId == null) {
                 return null;
             }

--- a/src/components/AutoTestSuite.vue
+++ b/src/components/AutoTestSuite.vue
@@ -227,7 +227,8 @@
 
     <b-card no-body v-if="!value.isEmpty()">
         <b-card-header class="suite-header d-flex align-items-center">
-            <span class="title">
+            <span class="title"
+                  v-if="rubricRow != null">
                 <a v-if="result"
                    href="#"
                    @click.capture.prevent.stop="$root.$emit('cg::rubric-viewer::open-category', rubricRow.id)">
@@ -236,6 +237,10 @@
                 <template v-else>
                     {{ rubricRow.header }}
                 </template>
+            </span>
+            <span v-else
+                  class="text-muted">
+                No rubric category selected.
             </span>
 
             <a href="#"


### PR DESCRIPTION
We used the values on the AutoTestSuite model before this, but those would not be updated when the rubric is changed. Now we always get the rubric rows from the store,  ensuring we use the correct rubric category headers.

DEV-146 #done 