### PR TITLE
Fix AutoTest suite table rendering

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -16,7 +16,8 @@ Version *Next*
 - Fix IPython ``execute_result`` cell outputs `(#1367)
   <https://github.com/CodeGra-de/CodeGra.de/pull/1367>`__.
 - Miscellaneous fixes:
-  `(#1373) <https://github.com/CodeGra-de/CodeGra.de/pull/1373>`__.
+  `(#1373) <https://github.com/CodeGra-de/CodeGra.de/pull/1373>`__,
+  `(#1375) <https://github.com/CodeGra-de/CodeGra.de/pull/1375>`__.
 
 Version *LowVoltage.1*
 ----------------------

--- a/src/components/AutoTestSet.vue
+++ b/src/components/AutoTestSet.vue
@@ -25,7 +25,7 @@
             </template>
         </span>
 
-        <masonry :gutter="30" :cols="{default: (result ? 1 : 2), [$root.xlargeWidth]: 1 }">
+        <masonry :gutter="30" :cols="{default: (result ? 1 : 2), [1.25 * $root.xlargeWidth]: 1 }">
             <auto-test-suite v-for="suite, j in value.suites"
                              class="mb-3"
                              :editable="editable"

--- a/src/components/AutoTestStep.vue
+++ b/src/components/AutoTestStep.vue
@@ -278,7 +278,7 @@
         </tr>
 
         <tr v-if="canViewOutput" class="results-log-collapse-row">
-            <td colspan="5">
+            <td :colspan="result ? 5 : 4">
                 <collapse :id="resultsCollapseId" class="container-fluid" lazy-load>
                     <div class="col-12 mb-3" slot-scope="{}">
                         You {{ stepResult.state === 'passed' ? 'scored' : 'did not score' }}
@@ -320,7 +320,7 @@
         </tr>
 
         <tr v-if="canViewOutput" class="results-log-collapse-row">
-            <td colspan="5">
+            <td :colspan="result ? 5 : 4">
                 <collapse :id="resultsCollapseId" lazy-load>
                     <b-card no-body slot-scope="{}">
                         <b-tabs card no-fade>
@@ -394,7 +394,7 @@
         </tr>
 
         <tr v-if="canViewDetails" class="results-log-collapse-row">
-            <td colspan="5">
+            <td :colspan="result ? 5 : 4">
                 <collapse :id="resultsCollapseId" lazy-load>
                     <template slot-scope="{}">
                         <b-card no-body v-if="canViewOutput">
@@ -555,7 +555,7 @@
             </tr>
 
             <tr v-if="canViewDetails" class="results-log-collapse-row">
-                <td colspan="5">
+                <td :colspan="result ? 5 : 4">
                     <collapse :id="`${resultsCollapseId}-${i}`" lazy-load>
                         <template slot-scope="{}">
                             <b-card no-body v-if="canViewSubStepOutput(i)">
@@ -1323,6 +1323,10 @@ export default {
 
         .caret + .fa-icon {
             margin-left: 0.333rem;
+        }
+
+        code {
+            word-break: break-word;
         }
     }
 }

--- a/src/components/AutoTestStep.vue
+++ b/src/components/AutoTestStep.vue
@@ -263,14 +263,16 @@
                       v-b-popover.hover.top="hiddenPopover" />
             </td>
             <td class="shrink">{{ index }}</td>
-            <td colspan="2">
-                <b>{{ stepName }}</b>
+            <td class="overflowable" colspan="2">
+                <div class="overflow-auto">
+                    <b>{{ stepName }}</b>
 
-                <template v-if="canViewDetails">
-                    Stop when you achieve less than
-                    <code>{{ value.data.min_points }}%</code>
-                    of the points possible.
-                </template>
+                    <template v-if="canViewDetails">
+                        Stop when you achieve less than
+                        <code>{{ value.data.min_points }}%</code>
+                        of the points possible.
+                    </template>
+                </div>
             </td>
             <td class="shrink text-center" v-if="result">
                 <auto-test-state :result="stepResult" show-icon />
@@ -300,13 +302,15 @@
                       v-b-popover.hover.top="hiddenPopover" />
             </td>
             <td class="shrink">{{ index }}</td>
-            <td>
-                <b>{{ stepName }}</b>
+            <td class="overflowable">
+                <div class="overflow-auto">
+                    <b>{{ stepName }}</b>
 
-                <template v-if="canViewDetails">
-                    Run <code>{{ value.data.program }}</code>
-                    and check for successful completion.
-                </template>
+                    <template v-if="canViewDetails">
+                        Run <code>{{ value.data.program }}</code>
+                        and check for successful completion.
+                    </template>
+                </div>
             </td>
             <td class="shrink text-center">
                 <template v-if="result">
@@ -375,12 +379,14 @@
                       v-b-popover.hover.top="hiddenPopover" />
             </td>
             <td class="shrink">{{ index }}</td>
-            <td>
-                <b>{{ stepName }}</b>
+            <td class="overflowable">
+                <div class="overflow-auto">
+                    <b>{{ stepName }}</b>
 
-                <template v-if="canViewDetails">
-                    Run <code>{{ value.data.program }}</code> and parse its output.
-                </template>
+                    <template v-if="canViewDetails">
+                        Run <code>{{ value.data.program }}</code> and parse its output.
+                    </template>
+                </div>
             </td>
             <td class="shrink text-center">
                 <template v-if="result">
@@ -532,16 +538,18 @@
                           v-b-popover.hover.top="hiddenPopover" />
                 </td>
                 <td class="shrink">{{ index }}.{{ i + 1 }}</td>
-                <td>
-                    <template v-if="canViewDetails && result">
-                        <b>{{ input.name }}</b>
+                <td class="overflowable">
+                    <div class="overflow-auto">
+                        <template v-if="canViewDetails && result">
+                            <b>{{ input.name }}</b>
 
-                        Run <code>{{ value.data.program }} {{ input.args }}</code>
-                        and match its output to an expected value.
-                    </template>
-                    <template v-else>
-                        {{ input.name }}
-                    </template>
+                            Run <code>{{ value.data.program }} {{ input.args }}</code>
+                            and match its output to an expected value.
+                        </template>
+                        <template v-else>
+                            {{ input.name }}
+                        </template>
+                    </div>
                 </td>
                 <td class="shrink text-center">
                     <template v-if="result">
@@ -1313,6 +1321,12 @@ export default {
             transform: translateY(2px);
         }
 
+        // Makes a block with overflow: auto placed in this cell actually
+        // overflow.
+        td.overflowable {
+            max-width: 0;
+        }
+
         .expand .fa-icon {
             transition: transform 300ms;
         }
@@ -1326,7 +1340,7 @@ export default {
         }
 
         code {
-            word-break: break-word;
+            word-wrap: initial;
         }
     }
 }


### PR DESCRIPTION
On some screen sizes (slightly above `1200px` wide) the AutoTest suite
tables were drawn outside of the card sometimes.

At first I thought this happened because the `colspan` attributes on the
collapsed table rows were wrong. They were always set to 5, but when no
result is present the rest of the table has only 4 columns. This did not
fix the problem, though.

In the end I found that it is caused by `<code>` tags containing long
unbreakable words. I tried to address the problem in two ways:

* Increase the minimum screen size required to render the test suites in
  two columns by 25%. Before the split was at `1200px`, so this is now
  `1500px`. This means that a single-column suite can now become quite
  wide, but I think it's better than the alternative of two columns
  becoming very narrow on screens slightly wider than `1200px`.
* Make the description table cell of a step scrollable when it contains a
  long word in a `<code>` tag.