### PR TITLE
DEV-175 Fix submission page category switching after initial load

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -16,7 +16,8 @@ Version *Next*
 - Fix IPython ``execute_result`` cell outputs `(#1367)
   <https://github.com/CodeGra-de/CodeGra.de/pull/1367>`__.
 - Miscellaneous fixes:
-  `(#1373) <https://github.com/CodeGra-de/CodeGra.de/pull/1373>`__.
+  `(#1373) <https://github.com/CodeGra-de/CodeGra.de/pull/1373>`__,
+  `(#1376) <https://github.com/CodeGra-de/CodeGra.de/pull/1376>`__.
 
 Version *LowVoltage.1*
 ----------------------

--- a/src/components/SubmissionList.vue
+++ b/src/components/SubmissionList.vue
@@ -109,7 +109,7 @@
     </b-table>
 
     <b-pagination
-        class="mt-3"
+        class="mt-3 mb-0"
         v-if="showPagination"
         v-model="currentPage"
         :limit="10"

--- a/src/pages/Submission.vue
+++ b/src/pages/Submission.vue
@@ -133,9 +133,9 @@
 
         <template slot="extra" v-if="!loadingInner">
             <category-selector slot="extra"
-                                :default="defaultCat"
-                                v-model="selectedCat"
-                                :categories="categories"/>
+                               :default="defaultCat"
+                               v-model="selectedCat"
+                               :categories="categories"/>
         </template>
     </local-header>
 
@@ -296,6 +296,7 @@ export default {
         return {
             assignmentState,
 
+            defaultCat: '',
             selectedCat: '',
             hiddenCats: new Set(),
 
@@ -584,27 +585,6 @@ export default {
             }
         },
 
-        defaultCat() {
-            const editable = this.editable;
-            const done = this.assignmentDone;
-            const hasFb = this.hasFeedback;
-            const testRun = this.autoTestRun;
-
-            if (done) {
-                if (hasFb) {
-                    return 'feedback-overview';
-                } else if (testRun) {
-                    return 'auto-test';
-                } else {
-                    return 'feedback-overview';
-                }
-            } else if (!editable && testRun) {
-                return 'auto-test';
-            } else {
-                return 'code';
-            }
-        },
-
         rubricStartOpen() {
             const done = this.assignmentDone;
             const editable = this.editable;
@@ -773,7 +753,7 @@ export default {
             });
         },
 
-        async loadData() {
+        loadData() {
             if (this.submissionId == null || this.error != null) {
                 return;
             }
@@ -832,8 +812,11 @@ export default {
                 );
             }
 
-            await Promise.all(promises).then(
-                this.openFirstFile,
+            Promise.all(promises).then(
+                () => {
+                    this.setDefaultCat();
+                    this.openFirstFile();
+                },
                 err => {
                     this.error = this.$utils.getErrorMessage(err);
                 },
@@ -944,6 +927,27 @@ export default {
             // half of the width of the page.
             if (wasHidden && tab === 'feedback' && this.splitRatio > 50) {
                 this.splitRatio = 50;
+            }
+        },
+
+        setDefaultCat() {
+            const editable = this.editable;
+            const done = this.assignmentDone;
+            const hasFb = this.hasFeedback;
+            const testRun = this.autoTestRun;
+
+            if (done) {
+                if (hasFb) {
+                    this.defaultCat = 'feedback-overview';
+                } else if (testRun) {
+                    this.defaultCat = 'auto-test';
+                } else {
+                    this.defaultCat = 'feedback-overview';
+                }
+            } else if (!editable && testRun) {
+                this.defaultCat = 'auto-test';
+            } else {
+                this.defaultCat = 'code';
             }
         },
     },

--- a/src/pages/Submission.vue
+++ b/src/pages/Submission.vue
@@ -931,23 +931,27 @@ export default {
         },
 
         setDefaultCat() {
-            const editable = this.editable;
-            const done = this.assignmentDone;
-            const hasFb = this.hasFeedback;
-            const testRun = this.autoTestRun;
+            this.defaultCat = this.getDefaultCat(
+                this.editable,
+                this.assignmentDone,
+                this.hasFeedback,
+                this.autoTestRun,
+            );
+        },
 
-            if (done) {
-                if (hasFb) {
-                    this.defaultCat = 'feedback-overview';
-                } else if (testRun) {
-                    this.defaultCat = 'auto-test';
+        getDefaultCat(feedbackEditable, assignmentDone, hasFeedback, autoTestRun) {
+            if (assignmentDone) {
+                if (hasFeedback) {
+                    return 'feedback-overview';
+                } else if (autoTestRun) {
+                    return 'auto-test';
                 } else {
-                    this.defaultCat = 'feedback-overview';
+                    return 'feedback-overview';
                 }
-            } else if (!editable && testRun) {
-                this.defaultCat = 'auto-test';
+            } else if (!feedbackEditable && autoTestRun) {
+                return 'auto-test';
             } else {
-                this.defaultCat = 'code';
+                return 'code';
             }
         },
     },

--- a/test/unit/specs/Submission.spec.js
+++ b/test/unit/specs/Submission.spec.js
@@ -303,7 +303,7 @@ describe('Submission.vue', () => {
             });
         });
 
-        describe('defaultCat', () => {
+        describe('setDefaultCat', () => {
             it('should be "Code" when the assignment is not done and there is no Continuous Feedback', async () => {
                 store.dispatch('courses/updateAssignment', {
                     assignmentId: comp.assignmentId,
@@ -312,8 +312,9 @@ describe('Submission.vue', () => {
                         auto_test_id: null,
                     },
                 });
-
                 await wait();
+                comp.setDefaultCat();
+
                 expect(comp.defaultCat).toBe('code');
             });
 
@@ -331,6 +332,7 @@ describe('Submission.vue', () => {
                     user: [],
                 });
                 await wait();
+                comp.setDefaultCat();
 
                 expect(comp.defaultCat).toBe('feedback-overview');
 
@@ -348,6 +350,7 @@ describe('Submission.vue', () => {
                     }],
                 })
                 await wait();
+                comp.setDefaultCat();
 
                 expect(comp.defaultCat).toBe('feedback-overview');
             });
@@ -365,6 +368,7 @@ describe('Submission.vue', () => {
                     user: {},
                 });
                 await wait();
+                comp.setDefaultCat();
 
                 expect(comp.defaultCat).toBe('feedback-overview');
             });
@@ -382,8 +386,9 @@ describe('Submission.vue', () => {
                     user: [],
                     linter: {},
                 });
-
                 await wait(100);
+                comp.setDefaultCat();
+
                 expect(comp.defaultCat).toBe('auto-test');
             });
 
@@ -397,6 +402,7 @@ describe('Submission.vue', () => {
                     },
                 });
                 await wait();
+                comp.setDefaultCat();
 
                 expect(comp.defaultCat).toBe('code');
 
@@ -421,6 +427,7 @@ describe('Submission.vue', () => {
                     },
                 });
                 await wait();
+                comp.setDefaultCat();
 
                 expect(comp.defaultCat).toBe('code');
             });

--- a/test/unit/specs/Submission.spec.js
+++ b/test/unit/specs/Submission.spec.js
@@ -241,8 +241,6 @@ describe('Submission.vue', () => {
 
     describe('Computed', () => {
         it('ids should be numbers', () => {
-            console.log(comp.course);
-            console.log(comp.courseId);
             expect(comp.courseId).toBeNumber();
             expect(comp.assignmentId).toBeNumber();
             expect(comp.submissionId).toBeNumber();
@@ -300,6 +298,40 @@ describe('Submission.vue', () => {
             it.each(['student', 'teacher', 'diff'])('should take the value from the route', (rev) => {
                 $route.query.revision = rev;
                 expect(comp.revision).toBe(rev);
+            });
+        });
+
+        describe('getDefaultCat', () => {
+            it.each([
+                [false, false, false, null, 'code'],
+                [false, false, false, {},   'auto-test'],
+                [false, false, true,  null, 'code'],
+                [false, false, true,  {},   'code'],
+                [false, true,  false, null, 'code'],
+                [false, true,  false, {},   'auto-test'],
+                [false, true,  true,  null, 'code'],
+                [false, true,  true,  {},   'code'],
+                [true,  false, false, null, 'feedback-overview'],
+                [true,  false, false, {},   'auto-test'],
+                [true,  false, true,  null, 'feedback-overview'],
+                [true,  false, true,  {},   'auto-test'],
+                [true,  true,  false, null, 'feedback-overview'],
+                [true,  true,  false, {},   'feedback-overview'],
+                [true,  true,  true,  null, 'feedback-overview'],
+                [true,  true,  true,  {},   'feedback-overview'],
+            ])('should behave correctly', (
+                assignmentDone,
+                hasFeedback,
+                feedbackEditable,
+                autoTestRun,
+                expected = 'code',
+            ) => {
+                expect(comp.getDefaultCat(
+                    feedbackEditable,
+                    assignmentDone,
+                    hasFeedback,
+                    autoTestRun,
+                )).toBe(expected);
             });
         });
 


### PR DESCRIPTION
The category switched because `defaultCat` was a computed property which
changed after deleting the final comment on a submission from the
feedback overview, when the feedback overview was the default category.

With this change the default category is set only once per submission,
so it will not change after the initial page load anymore.

DEV-175 #done