### PR TITLE
DEV-175 Fix disabled grade viewer popover

### DIFF
--- a/src/components/GradeViewer.vue
+++ b/src/components/GradeViewer.vue
@@ -176,9 +176,13 @@ export default {
 
         globalPopover() {
             if (this.notLatest) {
-                return `This is not the latest submission by ${this.$utils.nameOfUser(
+                let msg = `This is not the latest submission by ${this.$utils.nameOfUser(
                     this.submission.user,
-                )} so you cannot edit the grade. This grade will not be passed back to your LMS`;
+                )} so you cannot edit the grade.`;
+                if (this.$ltiProvider != null) {
+                    msg += ` This grade will not be passed back to ${this.$ltiProvider.lms}.`;
+                }
+                return msg;
             } else if (this.groupOfUser) {
                 return `This user is member of the group "${
                     this.groupOfUser.group.name


### PR DESCRIPTION
The popover always said "This grade will not be passed back to your
LMS", even when the CodeGrade instance is not connected to an LMS. This
changes the message to only include that text when the instance is, in
fact, connected to an LMS, and shows the LMS's name instead of of "your
LMS".

DEV-175 #done