### PR TITLE
DEV-157 Add more rubric category information to rubric analytics tooltips

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -10,6 +10,8 @@ Version *Next*
 
 - Automatically focus the percentage input in continuous rubric rows
   `(#1370) <https://github.com/CodeGra-de/CodeGra.de>`__.
+- Add more rubric category information to the rubric analytics graphs
+  `(#1383) <https://github.com/CodeGra-de/CodeGra.de/pull/1383>`__.
 
 **Fixes**
 

--- a/src/components/AnalyticsRubricStats.vue
+++ b/src/components/AnalyticsRubricStats.vue
@@ -245,7 +245,6 @@ export default {
 
             const label = (tooltipItem, data) => {
                 const ds = getDataset(tooltipItem, data);
-
                 return ds.label;
             };
 
@@ -256,7 +255,7 @@ export default {
                 const stats = ds.stats[tooltipItem.index];
 
                 // Do not escape, chart.js does its own escaping.
-                const items = [
+                return [
                     `Max. points: ${stats.rubricRow.maxPoints}`,
                     `Times filled: ${stats.nTimesFilled}`,
                     `Mean: ${numOrDash(stats.mean)}`,
@@ -266,8 +265,6 @@ export default {
                     `Rit: ${numOrDash(stats.rit) || '-'}`,
                     `Rir: ${numOrDash(stats.rir) || '-'}`,
                 ];
-
-                return items;
             };
 
             const labelString = this.metricOptions.find(so => so.value === this.settings.metric)
@@ -362,11 +359,9 @@ export default {
                         rit: source.ritPerCat[row.id],
                         rir: source.rirPerCat[row.id],
                         nTimesFilled: source.nTimesFilledPerCat[row.id],
-                        rowMaxPoints: row.maxPoints,
                         rowId: row.id,
                         rubricRow: row,
                     };
-
                     stats.push(rowStats);
                     // Make sure we render at least a minimal bar for each
                     // datapoint, otherwise we will not get a popover.


### PR DESCRIPTION
Adds some more information about the rubric category to the tooltips in the rubric analytics graphs. This includes:

* An `(AutoTest)` label appended to the category title in the tooltip.
* The maximum amount of points that can be scored in the rubric category. This is currently only displayed in the tooltip, but it might be nice to visualise it in the graph. Something like the second category in the mockup below (the average score is 1.5 out of a maximum of 2 points). But I think that is something for later.

![rubric-max-points-line](https://user-images.githubusercontent.com/3612514/85002590-5edb7a80-b155-11ea-9c61-c82db4d48ab1.png)


DEV-157 #done