### PR TITLE
DEV-176 Remove link from logo in email template

### DIFF
--- a/psef/mail_templates/base.j2
+++ b/psef/mail_templates/base.j2
@@ -427,9 +427,7 @@
                                                              <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" class="mcnImageContentContainer" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
                                                                  <tbody><tr>
                                                                          <td class="mcnImageContent" valign="top" style="padding-right: 9px;padding-left: 9px;padding-top: 0;padding-bottom: 0;text-align: center;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-                                                                             <a href="{{ site_url }}" title="" class="" target="_blank" style="mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
-                                                                                 <img align="center" alt="CodeGrade Logo" src="{{ site_url }}/static/img/codegrade-inv.png" width="250" style="max-width: 250px;padding-bottom: 0;display: inline !important;vertical-align: bottom;border: 0;height: auto;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;" class="mcnImage">
-                                                                             </a>
+                                                                             <img align="center" alt="CodeGrade Logo" src="{{ site_url }}/static/img/codegrade-inv.png" width="250" style="max-width: 250px;padding-bottom: 0;display: inline !important;vertical-align: bottom;border: 0;height: auto;outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;" class="mcnImage">
                                                                          </td>
                                                                      </tr>
                                                                  </tbody>


### PR DESCRIPTION
We should still test this in a few email clients.

DEV-176 #done