### PR TITLE
DEV-199 Do not close general feedback when it has been edited

### DIFF
--- a/src/components/GeneralFeedbackArea.vue
+++ b/src/components/GeneralFeedbackArea.vue
@@ -9,7 +9,7 @@
     <component :is="inPopover ? 'b-popover' : 'div'"
                :id="popoverId"
                ref="popover"
-               triggers="click blur"
+               :triggers="feedbackChanged ? 'click' : 'click blur'"
                :target="btnId"
                :placement="placement"
                :boundary="boundary"


### PR DESCRIPTION
I can see two options for this behaviour:

* Do not close the general feedback when interacting with the page only if the text in the textarea has been changed since opening the general feedback.
* Never close the general feedback area by page interaction, except when clicking the button that opens it for a second time.

But it is not clear from the issue which one is intended... I've gone for the former, but the latter would allow us to remove a lot of (probably buggy) code dealing with the popover state.

DEV-199 #done