### PR TITLE
Replace the semVer badge with the latest release date

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@
       alt="Latest release" title="Latest release">
   </a>
   <a href="https://github.com/CodeGra-de/CodeGra.de/releases">
-    <img src="https://img.shields.io/badge/semVer-✓-brightgreen.svg"
-      alt="Semantic Version: ✓" title="Semantic Version">
+    <img src="https://img.shields.io/github/release-date/CodeGra-de/CodeGra.de.svg"
+      alt="Latest release" title="Latest release">
   </a>
   <a href="https://github.com/CodeGra-de/CodeGra.de/pulls">
     <img src="https://img.shields.io/github/issues-pr-raw/CodeGra-de/CodeGra.de.svg"


### PR DESCRIPTION
We don't use version anymore, so the semVer badge did not make sense. Of course we don't want to just remove a badge, so I've replaced it with the latest release date because

* that's obviously very useful to know ;-)
* it will be green most of the time because we release frequently
* it fits nicely in the spot where the semver badge used to be, right after the latest release name