### PR TITLE
DEV-243 Use capture points step state icons for unit test step

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -6,6 +6,13 @@ Version *Next*
 
 **Released**: TBD
 
+**Updates**
+
+- Use the same icons from the "Capture Points" AutoTest step for the "Unit
+  Test" step `(#1403) <https://github.com/CodeGra-de/CodeGra.de/pull/1403>`__.
+  The "Unit Test" step would always use the green checkmark if the step did not
+  crash, but now the icon depends on the score achieved.
+
 Version Mosaic
 ---------------
 

--- a/src/models/auto_test.js
+++ b/src/models/auto_test.js
@@ -356,7 +356,7 @@ export class AutoTestResult {
                             }
                             break;
                         case 'custom_output':
-                        case 'unit_test':
+                        case 'junit_test':
                             if (stepResult.state === 'passed') {
                                 const points = stepResult.log.points;
                                 if (points === 0) {

--- a/src/models/auto_test.js
+++ b/src/models/auto_test.js
@@ -349,15 +349,25 @@ export class AutoTestResult {
                     }
                     stepResult.step = step;
 
-                    if (step.type === 'check_points' && stepResult.state === 'failed') {
-                        suiteFailed = true;
-                    } else if (step.type === 'custom_output' && stepResult.state === 'passed') {
-                        const points = stepResult.log.points;
-                        if (points === 0) {
-                            stepResult.state = 'failed';
-                        } else if (points < 1) {
-                            stepResult.state = 'partial';
-                        }
+                    switch (step.type) {
+                        case 'check_points':
+                            if (stepResult.state === 'failed') {
+                                suiteFailed = true;
+                            }
+                            break;
+                        case 'custom_output':
+                        case 'unit_test':
+                            if (stepResult.state === 'passed') {
+                                const points = stepResult.log.points;
+                                if (points === 0) {
+                                    stepResult.state = 'failed';
+                                } else if (points < 1) {
+                                    stepResult.state = 'partial';
+                                }
+                            }
+                            break;
+                        default:
+                            break;
                     }
 
                     suiteResult.achieved += getProps(stepResult, 0, 'achieved_points');


### PR DESCRIPTION
The new Unit Test step always had a green checkmark as its state, even when none of the tests passed. This changes its behaviour to be the same as the Capture Points test, i.e. a green checkmark only when all tests passed, a black tilde if some but not all tests passed, and a red cross when all tests failed or you achieved 0 points in some other way.

DEV-243 #finished