### PR TITLE
Stop silently ignoring errors

### DIFF
--- a/src/components/SubmissionList.vue
+++ b/src/components/SubmissionList.vue
@@ -430,10 +430,15 @@ export default {
                         submissionProps: { assignee: newAssignee },
                     });
                 },
-                ({ response }) => {
-                    // TODO: visual feedback
-                    // eslint-disable-next-line
-                    console.log(response);
+                err => {
+                    this.$set(this.assigneeUpdating, submission.id, false);
+                    this.$bvToast.toast(err.response.data.message, {
+                        title: 'Error',
+                        toaster: 'b-toaster-top-right',
+                        variant: 'danger',
+                        noAutoHide: true,
+                        solid: true,
+                    });
                 },
             );
         },

--- a/src/components/UsersManager.vue
+++ b/src/components/UsersManager.vue
@@ -408,29 +408,35 @@ export default {
         },
 
         changed(user, role) {
-            for (let i = 0, len = this.users.length; i < len; i += 1) {
-                if (this.users[i].User.id === user.User.id) {
-                    this.$set(user, 'CourseRole', role);
-                    this.$set(this.users, i, user);
-                    break;
-                }
-            }
             this.$set(this.updating, user.User.id, true);
             const req = this.$http.put(`/api/v1/courses/${this.courseId}/users/`, {
                 user_id: user.User.id,
                 role_id: role.id,
             });
 
-            waitAtLeast(250, req)
-                .then(() => {
-                    this.$set(this.updating, user.User.id, false);
-                    delete this.updating[user.User.id];
-                })
-                .catch(err => {
-                    // TODO: visual feedback
-                    // eslint-disable-next-line
-                    console.dir(err);
-                });
+            waitAtLeast(250, req).then(
+                () => {
+                    for (let i = 0, len = this.users.length; i < len; i += 1) {
+                        if (this.users[i].User.id === user.User.id) {
+                            this.$set(user, 'CourseRole', role);
+                            this.$set(this.users, i, user);
+                            break;
+                        }
+                    }
+                },
+                err => {
+                    this.$bvToast.toast(err.response.data.message, {
+                        title: 'Error',
+                        toaster: 'b-toaster-top-right',
+                        variant: 'danger',
+                        noAutoHide: true,
+                        solid: true,
+                    });
+                },
+            ).then(() => {
+                this.$set(this.updating, user.User.id, false);
+                delete this.updating[user.User.id];
+            });
         },
 
         addUser() {


### PR DESCRIPTION
There were still some places where, if an error occurred, we would only log it and do nothing else. Those places were:

* Changing a user's role within a course.
* Changing the assignee of a submission.

While we still haven't got a great solution for them, I think showing a toast with the error message received from the backend is already much better than showing the user nothing.

!ignore changelog