### PR TITLE
DEV-242 Make # of Peer Feedback comments more clear

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -6,6 +6,13 @@ Version *Next*
 
 **Released**: TBD
 
+**Updates**
+
+- Make the peer feedback counters for students more clear `(#1406)
+  <https://github.com/CodeGra-de/CodeGra.de/pull 1406>`__. This changes the
+  counters with the number of comments students have given to their peirs to be
+  clearer and give more detailed information.
+
 Version Mosaic
 ---------------
 


### PR DESCRIPTION
This changes the badges containing the number of comments in the PeerFeedbackOverview component. The badges now always only contain the number of comments on the latest submission of the reviewed student. If the logged in student has given feedback to older submissions of their subject, the badge will get `variant="warning"` and gets a popover on hover. If the logged in user hasn't given any peer feedback to one of their subjects, the badge will be `variant="secondary"`. Lastly, if the user has given peer feedback, and all of their peer feedback was on the latest submission, the badge will be `variant="primary"`.

DEV-242 #done