### PR TITLE
Improve the "Upgrade available" toasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ PRIVACY_STATEMENT.md
 /src/userConfig.[jt]s
 .#*
 /src/userConfig.ts
+/static/commitHash

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -10,6 +10,8 @@ const InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
 var MiniCssExtractPlugin = require('mini-css-extract-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const CreateFileWebpack = require('./createFile')
+const userConfig = require('./userConfig')
 
 var env = process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -69,6 +71,11 @@ var webpackConfig = merge(baseWebpackConfig, {
     new webpack.HashedModuleIdsPlugin(),
 
 
+    new CreateFileWebpack({
+        path: path.resolve(__dirname, '../static/'),
+        fileName: 'commitHash',
+        content: userConfig.release.commitHash,
+    }),
     // copy custom static assets
     new CopyWebpackPlugin([
       {

--- a/src/main.js
+++ b/src/main.js
@@ -423,8 +423,16 @@ Promise.all([
             },
 
             async _checkForUpdates() {
-                const res = await this.$http.get('/api/v1/about').catch(() => ({ data: {} }));
-                if (UserConfig.isProduction && res.data.commit !== UserConfig.release.commitHash) {
+                const res = await this.$http
+                    .get(
+                        utils.buildUrl(['static', 'commitHash'], {
+                            query: { cacheBuster: Math.random() },
+                        }),
+                    )
+                    .catch(() => null);
+                const ourCommit = UserConfig.release.commitHash;
+                const remoteCommit = utils.getProps(res, ourCommit, 'data');
+                if (UserConfig.isProduction && ourCommit !== remoteCommit) {
                     this.$emit('cg::app::toast', {
                         tag: 'UpdateAvailable',
                         title: 'CodeGrade update available!',

--- a/src/utils/typed.ts
+++ b/src/utils/typed.ts
@@ -179,7 +179,7 @@ export class AssertionError extends Error {
 export function buildUrl(
     parts: ReadonlyArray<string | number> | string,
     args: {
-        query?: Record<string, string>;
+        query?: Record<string, string | number>;
         hash?: string;
         addTrailingSlash?: boolean;
     } & OneOrOther<AllOrNone<{
@@ -221,7 +221,7 @@ export function buildUrl(
         if (queryEntries.length > 0) {
             const params = queryEntries
                 .reduce((acc, [key, value]) => {
-                    acc.append(key, value);
+                    acc.append(key, coerceToString(value));
                     return acc;
                 }, new URLSearchParams())
                 .toString();


### PR DESCRIPTION
This changes two things:
1. It builds a static file that contains the commit hash of the latest front-end
version of CodeGrade available. This fixes the problem when the backend was
already restarted but the frontend was still building, in this case the toast
was visible but reloading didn't actually update the frontend. This also reduces
some of the load on the backend.
2. When the request fails for whatever reason we used to show the toast, now we
never show the toast as the most common case is that there is actually no new
version available.