### PR TITLE
Fix calculating metadata for broker

### DIFF
--- a/cg_sqlalchemy_helpers/__init__.py
+++ b/cg_sqlalchemy_helpers/__init__.py
@@ -10,7 +10,7 @@ import typing as t
 
 import sqlalchemy
 from flask import Flask, g
-from sqlalchemy import func, event
+from sqlalchemy import event
 from sqlalchemy.orm import deferred as _deferred
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy_utils import UUIDType as _UUIDType
@@ -21,7 +21,7 @@ from cg_dt_utils import DatetimeWithTimezone
 from . import types, mixins
 from .types import (
     ARRAY, JSONB, TIMESTAMP, CIText, DbEnum, DbType, Comparator, TypeDecorator,
-    tuple_, distinct, expression, hybrid_property, hybrid_expression
+    func, tuple_, distinct, expression, hybrid_property, hybrid_expression
 )
 
 UUID_LENGTH = len(str(uuid.uuid4()))  # 36

--- a/cg_sqlalchemy_helpers/types.py
+++ b/cg_sqlalchemy_helpers/types.py
@@ -591,7 +591,19 @@ class DbColumn(t.Generic[T]):  # pragma: no cover
     def __or__(self, other: 'DbColumn[bool]') -> 'DbColumn[bool]':
         ...
 
+    def __truediv__(
+        self: 'DbColumn[T_NUM]', other: 'DbColumn[T_NUM]'
+    ) -> 'DbColumn[T_NUM]':
+        ...
+
     def cast(self, other: DbType[Y]) -> 'DbColumn[Y]':
+        ...
+
+
+class FilterableDbColumn(t.Generic[T], DbColumn[T]):  # pragma: no cover
+    def filter(
+        self: 'FilterableDbColumn[T]', *criterion: 'FilterColumn'
+    ) -> 'FilterableDbColumn[T]':
         ...
 
 
@@ -861,20 +873,29 @@ if t.TYPE_CHECKING and MYPY:
                              coltype: object) -> t.Callable[[object], object]:
             return lambda x: x
 
-    class _func:
-        def count(self, _to_count: DbColumn[t.Any] = None) -> DbColumn[int]:
+    class func:
+        @staticmethod
+        def count(_to_count: DbColumn[t.Any] = None) -> DbColumn[int]:
             ...
 
-        def random(self) -> DbColumn[object]:
+        @staticmethod
+        def random() -> DbColumn[object]:
             ...
 
-        def max(self, col: DbColumn[T]) -> DbColumn[T]:
+        @staticmethod
+        def min(col: DbColumn[T]) -> FilterableDbColumn[t.Optional[T]]:
             ...
 
-        def sum(self, col: DbColumn[T_NUM]) -> DbColumn[T_NUM]:
+        @staticmethod
+        def max(col: DbColumn[T]) -> FilterableDbColumn[t.Optional[T]]:
             ...
 
-        def lower(self, col: DbColumn[str]) -> DbColumn[str]:
+        @staticmethod
+        def sum(col: DbColumn[T_NUM]) -> DbColumn[t.Optional[T_NUM]]:
+            ...
+
+        @staticmethod
+        def lower(col: DbColumn[str]) -> DbColumn[str]:
             ...
 
     def distinct(_distinct: T_DB_COLUMN) -> T_DB_COLUMN:
@@ -885,7 +906,7 @@ if t.TYPE_CHECKING and MYPY:
         ...
 
     class expression:
-        func: _func
+        func: func
 
         @staticmethod
         def and_(*to_and: FilterColumn) -> DbColumn[bool]:
@@ -912,6 +933,7 @@ else:
     from sqlalchemy import TypeDecorator, TIMESTAMP
     from sqlalchemy.dialects.postgresql import JSONB, ARRAY
     from sqlalchemy.sql import expression
+    from sqlalchemy import func
     from citext import CIText
     from sqlalchemy import distinct, tuple_
 

--- a/psef/models/auto_test.py
+++ b/psef/models/auto_test.py
@@ -817,13 +817,13 @@ class AutoTestRun(Base, TimestampMixin, IdMixin):
                 )
             ),
         ).with_entities(
-            sql_func.max(AutoTestResult.updated_at).filter(
+            sql_func.min(AutoTestResult.updated_at).filter(
                 AutoTestResult.state == ATStepResultState.not_started,
             ),
-            sql_func.max(AutoTestResult.started_at).filter(
+            sql_func.min(AutoTestResult.started_at).filter(
                 AutoTestResult.state == ATStepResultState.running,
             ),
-            sql_func.min(AutoTestResult.updated_at).filter(
+            sql_func.max(AutoTestResult.updated_at).filter(
                 AutoTestResult.state == ATStepResultState.passed,
             ),
         )

--- a/psef/models/auto_test.py
+++ b/psef/models/auto_test.py
@@ -10,15 +10,16 @@ import numbers
 import itertools
 
 import structlog
-from sqlalchemy import orm
-from sqlalchemy import func as sql_func
-from sqlalchemy import distinct
+from sqlalchemy import orm, distinct
 from sqlalchemy.sql.expression import or_, and_, case, nullsfirst
 
 import psef
+import cg_helpers
 from cg_dt_utils import DatetimeWithTimezone
 from cg_flask_helpers import callback_after_this_request
-from cg_sqlalchemy_helpers import UUIDType, deferred, hybrid_property
+from cg_sqlalchemy_helpers import UUIDType
+from cg_sqlalchemy_helpers import func as sql_func
+from cg_sqlalchemy_helpers import deferred, hybrid_property
 from cg_sqlalchemy_helpers.mixins import IdMixin, UUIDMixin, TimestampMixin
 
 from . import Base, MyQuery, DbColumn, db
@@ -806,51 +807,36 @@ class AutoTestRun(Base, TimestampMixin, IdMixin):
         :returns: A mapping that should be send to the broker in the metadata
             under the ``results`` key.
         """
-
-        # NOTE: This function does three separate database queries, as each
-        # query either sorts by a different column, or sorts in a different
-        # direction. It is probably possible to reduce this to two queries,
-        # however these queries are pretty fast and don't seem to be a bottle
-        # neck at this moment.
-
-        def get_latest_date(
-            state: auto_test_step_models.AutoTestStepResultState,
-            col: t.Union[DbColumn[DatetimeWithTimezone], DbColumn[
-                t.Optional[DatetimeWithTimezone]]],
-            oldest: bool = True,
-        ) -> t.Optional[str]:
-            date = db.session.query(AutoTestResult).filter(
-                AutoTestResult.run == self,
-                AutoTestResult.state == state,
-            ).join(work_models.Work).filter(
-                ~work_models.Work.deleted,
-            ).order_by(
-                col if oldest else col.desc(),
-            ).with_entities(col).limit(1).scalar()
-
-            if date is None:
-                return None
-            return date.isoformat()
-
         ATStepResultState = auto_test_step_models.AutoTestStepResultState
 
+        query = db.session.query(AutoTestResult).filter(
+            AutoTestResult.run == self,
+            AutoTestResult.work_id.in_(
+                self.auto_test.assignment.get_from_latest_submissions(
+                    work_models.Work.id
+                )
+            ),
+        ).with_entities(
+            sql_func.max(AutoTestResult.updated_at).filter(
+                AutoTestResult.state == ATStepResultState.not_started,
+            ),
+            sql_func.max(AutoTestResult.started_at).filter(
+                AutoTestResult.state == ATStepResultState.running,
+            ),
+            sql_func.min(AutoTestResult.updated_at).filter(
+                AutoTestResult.state == ATStepResultState.passed,
+            ),
+        )
+
+        def maybe_format(date: t.Optional[DatetimeWithTimezone]
+                         ) -> t.Optional[str]:
+            return cg_helpers.on_not_none(date, lambda d: d.isoformat())
+
+        not_started, running, passed = query.one()
         return {
-            'not_started':
-                get_latest_date(
-                    ATStepResultState.not_started,
-                    AutoTestResult.updated_at,
-                ),
-            'running':
-                get_latest_date(
-                    ATStepResultState.running,
-                    AutoTestResult.started_at,
-                ),
-            'passed':
-                get_latest_date(
-                    ATStepResultState.passed,
-                    AutoTestResult.updated_at,
-                    False,
-                ),
+            'not_started': maybe_format(not_started),
+            'running': maybe_format(running),
+            'passed': maybe_format(passed),
         }
 
     def get_broker_metadata(self) -> t.Mapping[str, object]:
@@ -925,8 +911,11 @@ class AutoTestRun(Base, TimestampMixin, IdMixin):
             isouter=True,
         ).having(
             or_(
-                amount_runners == 0, amount_results / amount_runners >
-                psef.app.config['AUTO_TEST_MAX_JOBS_PER_RUNNER']
+                amount_runners == 0,
+                (
+                    amount_results / amount_runners >
+                    psef.app.config['AUTO_TEST_MAX_JOBS_PER_RUNNER']
+                ),
             )
         ).group_by(cls.id).order_by(
             nullsfirst(


### PR DESCRIPTION
We now reuse the correct way to determine which submissions to consider (latest
only). As this makes the query slower I also merged the three separate queries
into a single one, which should give the db engine some options for
optimizations.