### PR TITLE
DEV-66 DEV-266 Improve markdown styling

### DIFF
--- a/src/components/InnerMarkdownViewer.vue
+++ b/src/components/InnerMarkdownViewer.vue
@@ -82,6 +82,30 @@ export default {
 @import '~mixins.less';
 
 .inner-markdown-viewer {
+    h1 {
+        font-size: 2.5em;
+    }
+
+    h2 {
+        font-size: 2em;
+    }
+
+    h3 {
+        font-size: 1.75em;
+    }
+
+    h4 {
+        font-size: 1.5em;
+    }
+
+    h5 {
+        font-size: 1.25em;
+    }
+
+    h6 {
+        font-size: 1em;
+    }
+
     pre {
         padding: 0.75rem 1.25rem;
         background-color: @color-lightest-gray;

--- a/src/components/InnerMarkdownViewer.vue
+++ b/src/components/InnerMarkdownViewer.vue
@@ -83,18 +83,25 @@ export default {
 
 .inner-markdown-viewer {
     pre {
-        margin-bottom: 1rem;
+        padding: 0.75rem 1.25rem;
+        background-color: @color-lightest-gray;
+        border-radius: 0.25rem;
         font-size: 100%;
         white-space: pre-wrap;
         word-wrap: break-word;
         word-break: break-word;
         hyphens: auto;
-        margin-left: 1.5rem;
+
+        @{dark-mode} {
+            color: @text-color-dark;
+            background-color: fade(@color-primary-darker, 50%);
+        }
     }
 
     img,
     .MathJax_SVG svg {
         max-width: 100%;
+
         @media @media-large {
             max-width: 30rem;
         }


### PR DESCRIPTION
This improves 2 (or 3) aspects of the markdown viewer:

* Code blocks now get a distinctive background so that it is obvious that it is a code block. Also, in dark mode code blocks had a dark text color, which was only barely readable on the dark background.

* Scale the font sizes in markdown headings relative to the rest of the document, rather than the root of the page.