### PR TITLE
Fix setting general assignment settings for LTI 1.1 assignments

### DIFF
--- a/src/components/AssignmentGeneralSettings.vue
+++ b/src/components/AssignmentGeneralSettings.vue
@@ -641,7 +641,7 @@ export default class AssignmentGeneralSettings extends Vue {
                     avail = formatDate(this.availableAt, null);
                 }
                 let maxGrade;
-                if (supportsBonusPoints) {
+                if (prov.supportsBonusPoints) {
                     maxGrade = this.maxGrade.orDefault(Nothing).extractNullable();
                 }
 

--- a/src/components/AssignmentGeneralSettings.vue
+++ b/src/components/AssignmentGeneralSettings.vue
@@ -629,28 +629,36 @@ export default class AssignmentGeneralSettings extends Vue {
             return formatNullableDate(date, true) ?? dflt;
         }
 
-        const { name, availableAt, deadline }: {
+        const { name, availableAt, deadline, maxGrade }: {
             name: string | undefined;
             availableAt: string | undefined | null;
             deadline: string | undefined;
+            maxGrade: number | null | undefined,
         } = this.assignment.ltiProvider.mapOrDefault(
             prov => {
                 let avail;
                 if (!prov.supportsStateManagement) {
                     avail = formatDate(this.availableAt, null);
                 }
+                let maxGrade;
+                if (supportsBonusPoints) {
+                    maxGrade = this.maxGrade.orDefault(Nothing).extractNullable();
+                }
+
                 return {
                     name: undefined as string | undefined,
                     deadline: (prov.supportsDeadline ?
                         undefined :
                         formatDate(setDeadline, undefined)),
                     availableAt: avail,
+                    maxGrade,
                 };
             },
             {
                 name: this.name ?? undefined,
                 availableAt: formatDate(this.availableAt, null),
                 deadline: formatDate(setDeadline, undefined),
+                max_grade: this.maxGrade.orDefault(Nothing).extractNullable(),
             },
         );
 
@@ -661,7 +669,7 @@ export default class AssignmentGeneralSettings extends Vue {
                 available_at: availableAt,
                 deadline,
                 kind: this.kind,
-                max_grade: this.maxGrade.orDefault(Nothing).extractNullable(),
+                max_grade: maxGrade,
                 send_login_links: this.isExam && this.sendLoginLinks,
             },
         });

--- a/src/components/AssignmentGeneralSettings.vue
+++ b/src/components/AssignmentGeneralSettings.vue
@@ -633,16 +633,16 @@ export default class AssignmentGeneralSettings extends Vue {
             name: string | undefined;
             availableAt: string | undefined | null;
             deadline: string | undefined;
-            maxGrade: number | null | undefined,
+            maxGrade?: number | null;
         } = this.assignment.ltiProvider.mapOrDefault(
             prov => {
                 let avail;
                 if (!prov.supportsStateManagement) {
                     avail = formatDate(this.availableAt, null);
                 }
-                let maxGrade;
+                let max;
                 if (prov.supportsBonusPoints) {
-                    maxGrade = this.maxGrade.orDefault(Nothing).extractNullable();
+                    max = this.maxGrade.orDefault(Nothing).extractNullable();
                 }
 
                 return {
@@ -651,14 +651,14 @@ export default class AssignmentGeneralSettings extends Vue {
                         undefined :
                         formatDate(setDeadline, undefined)),
                     availableAt: avail,
-                    maxGrade,
+                    maxGrade: max,
                 };
             },
             {
                 name: this.name ?? undefined,
                 availableAt: formatDate(this.availableAt, null),
                 deadline: formatDate(setDeadline, undefined),
-                max_grade: this.maxGrade.orDefault(Nothing).extractNullable(),
+                maxGrade: this.maxGrade.orDefault(Nothing).extractNullable(),
             },
         );
 


### PR DESCRIPTION
Many LTI 1.1 providers do not allow bonus points, and therefore the `maxGrade`
attribute should not been provided.