### PR TITLE
Expand inline links in markdown viewers

### DIFF
--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -33,7 +33,7 @@ Version *Next*
 Updates
 ^^^^^^^^^^^^^^^^^^^^
 
-- Automatically turn http and https URLs in markdown into clickable links
+- Automatically turn http and https URLs in markdown into clickable links `(#1448)
   <https://github.com/CodeGra-de/CodeGra.de/pull/1448>`__.
 
 Version Mosaic.1

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -33,8 +33,10 @@ Version *Next*
 Updates
 ^^^^^^^^^^^^^^^^^^^^
 
-- Automatically turn http and https URLs in markdown into clickable links `(#1448)
-  <https://github.com/CodeGra-de/CodeGra.de/pull/1448>`__.
+- Expand inline links in markdown viewer `(#1448)
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1448>`__. When you use http
+  or https URLs in your markdown feedback, they are automatically turned into
+  clickable links.
 
 Version Mosaic.1
 -----------------

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -30,6 +30,12 @@ Version *Next*
 
 **Released**: TBD
 
+Updates
+^^^^^^^^^^^^^^^^^^^^
+
+- Automatically turn http and https URLs in markdown into clickable links
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1448>`__.
+
 Version Mosaic.1
 -----------------
 

--- a/src/cg-math/index.js
+++ b/src/cg-math/index.js
@@ -25,7 +25,13 @@ export class CgMarkdownIt {
                 const inner = highlightCode(str.split('\n'), lang).join('<br>');
                 return `<pre class="code-block"><code>${inner}</code></pre>`;
             },
+            linkify: true,
         });
+        this.md.linkify
+            .set({ fuzzyLink: false })
+            .add('ftp:', null)
+            .add('//', null)
+            .add('mailto:', null);
 
         // Remember old renderer, if overridden, or proxy to default renderer
         const defaultRender =


### PR DESCRIPTION
This makes it easier to add links inside markdown blocks.