### PR TITLE
Fix error when group member states cant be loaded

### DIFF
--- a/src/components/GroupManagement.vue
+++ b/src/components/GroupManagement.vue
@@ -271,6 +271,7 @@ action is required.${divEnd}`;
 
             this.group
                 .getMemberStates(this.assignment.id)
+                // TODO: Show error when request failed.
                 .then(({ data }) => cont(data), () => cont());
         },
 

--- a/src/components/GroupManagement.vue
+++ b/src/components/GroupManagement.vue
@@ -260,7 +260,9 @@ action is required.${divEnd}`;
             // setInterval is not used as this might cause a large load on the
             // server. Now we know there is `timeoutTime` between each request.
             const cont = data => {
-                this.memberStates = data;
+                if (data != null) {
+                    this.memberStates = data;
+                }
                 this.updateStates = null;
                 if (this.showLtiProgress && !this.compDestroyed) {
                     this.updateStates = setTimeout(() => this.reloadGroupStates(), timeoutTime);
@@ -269,7 +271,7 @@ action is required.${divEnd}`;
 
             this.group
                 .getMemberStates(this.assignment.id)
-                .then(({ data }) => cont(data), ({ data }) => cont(data));
+                .then(({ data }) => cont(data), () => cont());
         },
 
         startEditTitle() {


### PR DESCRIPTION
The error occurred because in the error case of the `this.group.getMemberStates(...).then` we tried to get the `data` attribute of the error, which does not exist. So we set `this.memberStates` to `undefined`, which causes an error that breaks the reload timer loop.

With this change we only overwrite `this.memberStates` if we got a valid response.