### PR TITLE
DEV-264 Fix double scrollbars in IPython viewer

### DIFF
--- a/src/components/InnerIPythonViewer.vue
+++ b/src/components/InnerIPythonViewer.vue
@@ -190,7 +190,6 @@ export default {
 
     .code {
         padding-right: 0;
-        overflow-x: hidden;
     }
 
     .inner-markdown-viewer,


### PR DESCRIPTION
Removing `overflow-x: hidden` from IPython `.output-cell .code` fixes
the double scrollbars on Firefox and Chrome. I don't think the
`overflow-x` could be very important, because the code viewer already
wraps code, so there would never be any overflow anyway.

TODO:

* [ ] Test on Edge
* [ ] Test on Safari

DEV-264 #done