### PR TITLE
Fix getting the Brightspace LTI provider in the frontend

### DIFF
--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -12,13 +12,17 @@ const defaultLTIProvider = Object.freeze(<const>{
 });
 export type LTIProvider = {
     readonly lms: string;
+    readonly tag?: string;
     readonly addBorder: boolean;
     readonly supportsDeadline: boolean;
     readonly supportsBonusPoints: boolean;
     readonly supportsStateManagement: boolean;
 };
 
-function makeLTI1p1Provider(name: string, override: Omit<LTIProvider, 'lms'> | null = null): Readonly<LTIProvider> {
+function makeLTI1p1Provider(
+    name: string,
+    override: Partial<Omit<LTIProvider, 'lms'>> | null = null,
+): Readonly<LTIProvider> {
     return Object.freeze(
         Object.assign({}, defaultLTIProvider, override, { lms: name }),
     );
@@ -26,7 +30,12 @@ function makeLTI1p1Provider(name: string, override: Omit<LTIProvider, 'lms'> | n
 
 const blackboardProvider = makeLTI1p1Provider('Blackboard');
 
-const brightSpaceProvider = makeLTI1p1Provider('Brightspace');
+const brightSpaceProvider = makeLTI1p1Provider('Brightspace', {
+    // In the backend we call Brightspace "BrightSpace" (with a capital S)
+    // so we need to override the tag that is used to identify the correct
+    // ltiProvider.
+    tag: 'BrightSpace',
+});
 
 const moodleProvider = makeLTI1p1Provider('Moodle');
 
@@ -84,7 +93,7 @@ const LTI1p1Lookup: Record<string, LTIProvider> = mapToObject([
     canvasProvider,
     moodleProvider,
     sakaiProvider,
-], prov => [prov.lms, prov]);
+], prov => [prov.tag || prov.lms, prov]);
 
 export function makeProvider(provider: LTIProviderServerData): LTIProvider {
     switch (provider.version) {

--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -13,17 +13,18 @@ const defaultLTI1p1Provider = Object.freeze(<const>{
 });
 export type LTIProvider = {
     readonly lms: string;
-    readonly tag?: string;
     readonly addBorder: boolean;
     readonly supportsDeadline: boolean;
     readonly supportsBonusPoints: boolean;
     readonly supportsStateManagement: boolean;
 };
 
+type LTI1p1Provider = LTIProvider & { tag?: string };
+
 function makeLTI1p1Provider(
     name: string,
-    override: Partial<Omit<LTIProvider, 'lms'>> | null = null,
-): Readonly<LTIProvider> {
+    override: Partial<Omit<LTI1p1Provider, 'lms'>> | null = null,
+): Readonly<LTI1p1Provider> {
     return Object.freeze(
         Object.assign({}, defaultLTI1p1Provider, override, { lms: name }),
     );

--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -4,7 +4,8 @@ import type { LTIProviderServerData } from '@/api/v1/lti';
 
 import { AssertionError, mapToObject } from '@/utils/typed';
 
-const defaultLTIProvider = Object.freeze(<const>{
+const defaultLTI1p1Provider = Object.freeze(<const>{
+    lms: 'LMS',
     addBorder: false,
     supportsDeadline: false,
     supportsBonusPoints: false,
@@ -24,7 +25,7 @@ function makeLTI1p1Provider(
     override: Partial<Omit<LTIProvider, 'lms'>> | null = null,
 ): Readonly<LTIProvider> {
     return Object.freeze(
-        Object.assign({}, defaultLTIProvider, override, { lms: name }),
+        Object.assign({}, defaultLTI1p1Provider, override, { lms: name }),
     );
 }
 
@@ -97,8 +98,10 @@ const LTI1p1Lookup: Record<string, LTIProvider> = mapToObject([
 
 export function makeProvider(provider: LTIProviderServerData): LTIProvider {
     switch (provider.version) {
-        case 'lti1.1':
-            return LTI1p1Lookup[provider.lms];
+        case 'lti1.1': {
+            const prov = LTI1p1Lookup[provider.lms];
+            return prov == null ? defaultLTI1p1Provider : prov;
+        }
         case 'lti1.3':
             return new LTI1p3ProviderCapabilties(provider.lms, provider.capabilities);
         default:

--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+import * as utils from '@/utils';
+
 // eslint-disable-next-line
 import type { LTIProviderServerData } from '@/api/v1/lti';
 
@@ -101,7 +103,14 @@ export function makeProvider(provider: LTIProviderServerData): LTIProvider {
     switch (provider.version) {
         case 'lti1.1': {
             const prov = LTI1p1Lookup[provider.lms];
-            return prov == null ? defaultLTI1p1Provider : prov;
+            if (prov == null) {
+                utils.withSentry(Sentry => {
+                    Sentry.captureMessage(`Unknown LTI provider: ${provider.lms}`);
+                });
+                return defaultLTI1p1Provider;
+            } else {
+                return prov;
+            }
         }
         case 'lti1.3':
             return new LTI1p3ProviderCapabilties(provider.lms, provider.capabilities);


### PR DESCRIPTION
In the backend we used the tag "BrightSpace" for the LMS while in the
frontend we expected it to be "Brightspace" (no capital S), so we
couldn't find it and it would throw an error.

This adds a new "tag" attribute to LTI1p1 providers to map the backend
tags to the correct LTIProvider instance.