### PR TITLE
Store snippets filter in the URL query params

### DIFF
--- a/src/components/SnippetManager.vue
+++ b/src/components/SnippetManager.vue
@@ -3,10 +3,10 @@
 <loader :scale="2" class="" v-if="loading"/>
 <div class="snippet-manager" v-else>
     <b-form-group class="filter-group">
-        <input v-model="filter"
+        <input :value="filter"
+               v-debounce="newFilter => { filter = newFilter }"
                class="form-control"
-               placeholder="Type to Search"
-               v-on:keyup.enter="submit"/>
+               placeholder="Type to search snippets" />
     </b-form-group>
 
     <table class="table table-striped snippets-table">
@@ -149,7 +149,7 @@ export default {
         return {
             loading: true,
             snippets: [],
-            filter: '',
+            filter: this.$route.query.filterSnippets || '',
             editingSnippet: null,
             saveConfirmMessage: '',
         };
@@ -425,6 +425,18 @@ export default {
                     cmpNoCase(a.key, b.key),
                 );
             },
+        },
+
+        filter() {
+            this.currentPage = 1;
+
+            const newQuery = Object.assign({}, this.$route.query);
+            newQuery.filterSnippets = this.filter || undefined;
+
+            this.$router.replace({
+                query: newQuery,
+                hash: this.$route.hash,
+            });
         },
     },
 

--- a/src/components/SnippetManager.vue
+++ b/src/components/SnippetManager.vue
@@ -428,8 +428,6 @@ export default {
         },
 
         filter() {
-            this.currentPage = 1;
-
             const newQuery = Object.assign({}, this.$route.query);
             newQuery.filterSnippets = this.filter || undefined;
 

--- a/test/unit/specs/SnippetManager.spec.js
+++ b/test/unit/specs/SnippetManager.spec.js
@@ -1,15 +1,17 @@
 /* SPDX-License-Identifier: AGPL-3.0-only */
 import SnippetManager from '@/components/SnippetManager';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import VueRouter from 'vue-router';
+import VDebounce from 'vue-debounce';
 import Vuex from 'vuex';
 import BootstrapVue from 'bootstrap-vue'
+import router from '@/router';
 
 jest.mock('axios');
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(BootstrapVue);
+localVue.use(VDebounce);
 
 const snippets = [
     { id: 1, key: 'key_abc', value: 'value_abc' },
@@ -82,6 +84,7 @@ describe('SnippetManager.vue', () => {
         });
 
         wrapper = shallowMount(SnippetManager, {
+            router,
             store,
             localVue,
             mocks: {


### PR DESCRIPTION
This also fixes an error that occurred when pressing <kbd>Enter</kbd> in the snippets search input, because we bound a nonexisting handler.