### PR TITLE
Make sure test students are never used as peer feedback

### DIFF
--- a/cg_sqlalchemy_helpers/types.py
+++ b/cg_sqlalchemy_helpers/types.py
@@ -744,10 +744,7 @@ class MyNonOrderableQuery(t.Generic[T]):  # pragma: no cover
         ...
 
     @t.overload
-    def with_entities(
-        self: 'MyNonOrderableQuery[t.Tuple[_T_BASE, _Y_BASE]]',
-        __arg: t.Type[_T_BASE],
-    ) -> 'MyQuery[_T_BASE]':
+    def with_entities(self, __arg: t.Type[_T_BASE]) -> 'MyQuery[_T_BASE]':
         ...
 
     @t.overload

--- a/psef_test/test_peer_feedback.py
+++ b/psef_test/test_peer_feedback.py
@@ -663,7 +663,8 @@ def test_peer_feedback_and_group_assignments(
 @pytest.mark.parametrize('enable_after', [False, True])
 @pytest.mark.parametrize('student_amount', [4])
 def test_peer_feedback_and_test_student(
-        test_client, logged_in, describe, admin_user, session, tomorrow, enable_after, student_amount
+    test_client, logged_in, describe, admin_user, session, tomorrow,
+    enable_after, student_amount
 ):
     with describe('setup'), logged_in(admin_user):
         course = helpers.create_course(test_client)


### PR DESCRIPTION
If we had an assignment that already had a submission by the test student before
peer feedback was enabled (or if the settings of the PF was adjusted after there
was a submission by the test student) we didn't filter this user out when doing
the assignments. This PR fixes that behavior, and it makes sure we don't count
submissions by the test student when determining if we can do the initial
division.

This change also makes use of the same way to actually retrieve the users with
submissions. This method is incorrect for group assignments (which are not
support in combination with peer feedback), but is quicker as it does less
logic.