### PR TITLE
Release hotfix Mosaic.1.2

### DIFF
--- a/cg_sqlalchemy_helpers/types.py
+++ b/cg_sqlalchemy_helpers/types.py
@@ -744,10 +744,7 @@ class MyNonOrderableQuery(t.Generic[T]):  # pragma: no cover
         ...
 
     @t.overload
-    def with_entities(
-        self: 'MyNonOrderableQuery[t.Tuple[_T_BASE, _Y_BASE]]',
-        __arg: t.Type[_T_BASE],
-    ) -> 'MyQuery[_T_BASE]':
+    def with_entities(self, __arg: t.Type[_T_BASE]) -> 'MyQuery[_T_BASE]':
         ...
 
     @t.overload

--- a/docs/about/changelog.rst
+++ b/docs/about/changelog.rst
@@ -30,6 +30,14 @@ Version *Next*
 
 **Released**: TBD
 
+Updates
+^^^^^^^^^^^^^^^^^^^^
+
+- Expand inline links in markdown viewer `(#1448)
+  <https://github.com/CodeGra-de/CodeGra.de/pull/1448>`__. When you use http
+  or https URLs in your markdown feedback, they are automatically turned into
+  clickable links.
+
 Version Mosaic.1
 -----------------
 

--- a/docs/guides/creating-a-canvas-assignment.rst
+++ b/docs/guides/creating-a-canvas-assignment.rst
@@ -8,8 +8,8 @@ Create a CodeGrade assignment in Canvas
 
 Creating a new CodeGrade assignment from within Canvas will correctly
 add this assignment to the corresponding course in CodeGrade, a new course will
-automatically be created in CodeGrade if not yet created in CodeGrade. Follow
-the steps below to create a new CodeGrade assignment in Canvas:
+automatically be created in CodeGrade if it does not yet exist in CodeGrade.
+Follow the steps below to create a new CodeGrade assignment in Canvas:
 
 1. Click the **"+ Assignment"** button in Canvas.
 

--- a/docs/guides/creating-an-assignment.rst
+++ b/docs/guides/creating-an-assignment.rst
@@ -12,4 +12,5 @@ Select your Learning Management System (LMS):
     In BrightSpace <creating-a-brightspace-assignment>
     In Canvas <creating-a-canvas-assignment>
     In Moodle <creating-a-moodle-assignment>
+    In Open edX <creating-an-open-edx-assignment>
     Standalone <creating-a-standalone-assignment>

--- a/docs/guides/creating-an-open-edx-assignment.rst
+++ b/docs/guides/creating-an-open-edx-assignment.rst
@@ -1,0 +1,47 @@
+Create a CodeGrade assignment in Open edX
+================================================
+
+.. note::
+
+    The guide below assumes CodeGrade has been successfully integrated into
+    your Open edX environment as external LTI app.
+
+Creating a new CodeGrade assignment from within Open edX will correctly
+add this assignment to the corresponding course in CodeGrade, a new course will
+automatically be created in CodeGrade if it does not yet exist in CodeGrade.
+Follow the steps below to create a new CodeGrade assignment in Open edX:
+
+1. Edit the unit in which you want to add CodeGrade and select
+   **Advanced** from the **Add New Component** section. Select **LTI Consumer**.
+
+2. Select **Edit** in the component that appears. This should open a modal in
+   which you can set up the CodeGrade assignment.
+
+3. Set the **Display Name** to the name of the assignment.
+
+4. The value for **LTI ID** depends on the configuration that your
+   administrator set, however this will probably be ``codegrade``.
+
+5. The **LTI URL** is ``https://app.codegra.de/api/v1/lti/launch/1``, however
+   for instances with a custom URL this will be different. Please contact us at
+   `support@codegrade.com <mailto:support@codegrade.com>`__.
+
+6. Now scroll all the way to the bottom and make sure the following options are
+   all set to **True**:
+
+   - Request user’s email
+   - Request user's full name
+   - Request user’s username
+
+7. Click the save button.
+
+.. note::
+
+    Grades are automatically sent back to Open edX after setting the
+    **assignment state** to (:fa:`check`) **Done** in CodeGrade. While the
+    assignment is in the (:fa:`check`) **Done** state, all grades and changes to
+    grades are immediately sent back to Open edX.
+
+.. note::
+    Students can hand in and review their feedback from within the CodeGrade
+    container in Open edX.

--- a/docs/guides/getting-started-with-codegrade-in-open-edx.rst
+++ b/docs/guides/getting-started-with-codegrade-in-open-edx.rst
@@ -1,0 +1,154 @@
+Getting started with CodeGrade in Open edX
+-----------------------------------------------
+
+.. include:: getting-started-introduction.rst
+
+Integration with Open edX
+=============================
+
+All functionalities are bundled in one complete environment for programming
+education, that integrates with Open edX. We use the LTI protocol to securely
+communicate and synchronise CodeGrade with Open edX. Most likely, CodeGrade has
+already been correctly integrated with Open edX by your system administrator,
+please contact us if not.
+
+CodeGrade accounts are automatically created and linked to current Open edX
+accounts. CodeGrade can be accessed both from **within Open edX**, showing a
+more narrow version of CodeGrade in a container on Open edX, or from the
+CodeGrade **standalone website**: *<your-institution>.codegra.de*. There is no
+difference between these two, and opening the standalone website via Open edX
+using the **“New tab”** button allows you to be automatically logged in.
+
+CodeGrade accounts that are automatically created and linked from within Open
+edX will not have a password, and are only accessible by the shared session with
+Open edX.
+
+.. include:: setup-password.rst
+
+Open edX synchronisation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following data is shared between CodeGrade and Open edX:
+
+- Usernames
+
+- Full names
+
+- Email addresses
+
+- Course names
+
+- Assignment names
+
+- Assignment state
+
+- Grades (only passed back from CodeGrade to Open edX)
+
+Setting up your course
+========================
+
+After creating your first CodeGrade assignment from within Open edX, a course
+will be automatically created in CodeGrade. To **manage** the course options
+**press “Courses”** (:fa:`book`), select your course and press the :fa:`cog`
+**icon**. Below is a brief overview of the tabs in course management.
+
+Members
+~~~~~~~~
+
+After a user (student, TA or teacher) opens a CodeGrade assignment in Open edX
+for the first time in your course, they will automatically be added as a member
+of the course, CodeGrade will use the **role** this user has in Open edX.  On
+this tab, you can **change the role** of a member if it’s not correct, for
+example, from **Student** to **TA**.
+
+.. warning::
+    CodeGrade will automatically use the role the user has in Open edX. In
+    general, it is not necessary to change roles, only do this if necessary.
+
+Permissions
+~~~~~~~~~~~~
+
+On this page, you can change the permissions of the roles in the course. For
+example, you could give your TAs more permissions. Every permission is explained
+by the :fa:`info` icon.
+
+.. warning::
+    The default permissions will probably suit your course.
+
+Groups
+~~~~~~~~~
+
+If you want to use groups, you can create group sets here. A group set can be
+used by multiple assignments in the same course. **CodeGrade does not
+synchronise groups with Open edX**, so make sure your assignments in Open edX
+are individual assignments (no group submission) and manage your groups in
+CodeGrade. **CodeGrade will automatically send back all grades and feedback to
+all individual group members to Open edX correctly.**
+
+Depending on permissions you can allow students to join a group themselves or
+only allow Teachers or TAs to add students to a group. If you want to
+**change** these permissions, you can do so on the **permissions** page
+explained above.  :ref:`Click here to learn more about setting up your groups
+<set-up-group-assignment>`.
+
+Setting up your assignment
+=============================
+
+By clicking the :fa:`cog` icon on an assignment you enter the **assignment
+management page**.  This page allows you to set up **groups**, run **linters**,
+start **plagiarism runs**, and add or edit the **rubric**.
+
+General
+~~~~~~~~~
+
+On the **“General”** page you can edit several general options. You can also select
+a group set to use, if you decide to make an assignment a group assignment.
+Furthermore you can set bonus points.
+
+.. warning::
+
+    Manage the **deadline** of the assignment in CodeGrade and **NOT** in Open edX.
+
+.. warning::
+
+    The name and points possible of the assignment are configured within Open edX.
+
+.. include:: includes/getting-started-general.rst
+
+Student Experience
+=====================
+
+Students hand in an assignment on **Open edX** via the CodeGrade container after
+opening the assignment or optionally via Git. After handing in, students can
+browse through their code to check if it is correctly handed in. Before handing
+in they can click on the **“rubric”** (:fa:`th`) button to show the rubric for
+this assignment.  This means students **know what is expected** of them.
+
+After an assignment is set to **“Done”** (:fa:`check`) grades are automatically
+sent back to Open edX. Students can then view their feedback inside the
+CodeGrade container in Open edX after clicking on their grade or navigating to
+the assignment.
+
+.. note::
+
+    If an assignment is in the **“Done”** (:fa:`check`) state, all new grades
+    or edits are passed back to Open edX immediately.
+
+After uploading, a student will find an overview of their **Code** (where they
+can browse through their handed in files), an overview of their **Feedback**
+and optionally an overview of the **AutoTest** results which can be filled in
+preliminarily with Continuous Feedback.
+
+.. note::
+
+    We recommend graders to make use of the standalone CodeGrade website, but
+    the CodeGrade container within Open edX is sufficient for students. It is
+    not possible for students to hand in assignments in the standalone
+    environment.
+
+Contact us and support
+========================
+If you have any questions, don’t hesitate to contact us. You can email us at
+`support@codegrade.com <mailto:support@codegrade.com>`_. In addition to
+questions and bug reports, we always love to get feedback and suggestions on
+how we can improve CodeGrade to better fit your education.

--- a/docs/guides/getting-started-with-codegrade.rst
+++ b/docs/guides/getting-started-with-codegrade.rst
@@ -11,4 +11,5 @@ Select your Learning Management System (LMS):
     In Canvas <getting-started-with-codegrade-in-canvas>
     In Moodle <getting-started-with-codegrade-in-moodle>
     In Sakai <getting-started-with-codegrade-in-sakai>
+    In Open edX <getting-started-with-codegrade-in-open-edx>
     Standalone <getting-started-with-codegrade-standalone>

--- a/docs/guides/setup-password.rst
+++ b/docs/guides/setup-password.rst
@@ -2,7 +2,9 @@ To use the CodeGrade Filesystem, you need to set up a password for your
 CodeGrade account.
 
 .. warning::
-    Always use a different password than the password you use to log into Canvas, Blackboard, Moodle or Brightspace.
+
+    Always use a different password than the password you use to log into
+    Canvas, Blackboard, Moodle, Brightspace, Sakai or Open edX.
 
 1. Navigate to the profile (:fa:`user-circle-o`) page.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25395,9 +25395,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/psef/lti/v1_1.py
+++ b/psef/lti/v1_1.py
@@ -1240,6 +1240,47 @@ class SakaiLTI(_BareRolesLTIProvider):
     """
 
 
+@lti_classes.register('Open edX')
+class OpenEdX(_BareRolesLTIProvider):
+    """The LTI class used for the Open edX LMS.
+    """
+
+    def __init__(
+        self,
+        params: t.Mapping[str, str],
+        lti_provider: models.LTI1p1Provider = None
+    ) -> None:
+        super().__init__(params, lti_provider)
+
+        if 'custom_component_display_name' not in self.launch_params:
+            raise APIException(
+                (
+                    "We couldn't find the assignment name. Please make sure"
+                    " you set the 'Display Name' option."
+                ), (
+                    'The custom_component_display_name property was missing from'
+                    ' launch_params'
+                ), APICodes.INVALID_STATE, 400
+            )
+        elif not urlparse(self.outcome_service_url).netloc:
+            raise APIException(
+                (
+                    'It seems like you launched CodeGrade from Studio, this'
+                    ' is not supported. When you open this link outside studio'
+                    ' it will work.'
+                ), (
+                    'The outcome service url was not a complete url, so this'
+                    ' launch was probably done from within Studio'
+                ), APICodes.INVALID_STATE, 400
+            )
+
+    @property
+    def assignment_name(self) -> str:
+        """The name of the current LTI assignment.
+        """
+        return self.launch_params['custom_component_display_name']
+
+
 @lti_classes.register('Moodle')
 class MoodleLTI(_BareRolesLTIProvider):
     """The LTI class used for the Moodle LMS.

--- a/psef_test/conftest.py
+++ b/psef_test/conftest.py
@@ -106,6 +106,7 @@ def make_app_settings(request):
                 'moodle_lti': ('Moodle', ['12345678']),
                 'sakai_lti': ('Sakai', ['12345678']),
                 'brightspace_lti': ('BrightSpace', ['12345678']),
+                'open_edx_lti': ('Open edX', ['12345678']),
             },
             'LTI_SECRET_KEY': 'hunter123',
             'SECRET_KEY': 'hunter321',

--- a/psef_test/test_lti.py
+++ b/psef_test/test_lti.py
@@ -2475,3 +2475,62 @@ def test_launch_upgraded_lti1p1_provider(
             'This provider has been upgraded to LTI 1.3' ==
             res['original_exception']['message']
         )
+
+
+def test_open_edx_launches(test_client, app, describe, tomorrow):
+    email = 'thomas@example.com'
+    name = 'A the A-er'
+    lti_id = 'USER_ID'
+
+    def do_launch(**extra_data):
+        status = extra_data.pop('status')
+        message = extra_data.pop('message', None)
+
+        with app.app_context():
+            data = {
+                'roles': 'urn:lti:role:ims/lis/Instructor',
+                'user_id': lti_id,
+                'lis_person_sourcedid': lti_id,
+                'lis_person_contact_email_primary': email,
+                'lis_person_name_full': name,
+                'context_id': 'NO_CONTEXT',
+                'context_title': 'WRONG_TITLE',
+                'resource_link_id': 'My link id',
+                'oauth_consumer_key': 'open_edx_lti',
+                'lis_outcome_service_url': '',
+                **extra_data,
+            }
+
+            res = test_client.post('/api/v1/lti/launch/1', data=data)
+            assert res.status_code in {302, 303}
+            url = urllib.parse.urlparse(res.headers['Location'])
+            blob_id = urllib.parse.parse_qs(url.query)['blob_id'][0]
+
+            test_client.req(
+                'post',
+                '/api/v1/lti/launch/2',
+                status,
+                data={'blob_id': blob_id},
+                result={
+                    '__allow_extra__': True,
+                    'message': message,
+                } if status != 200 else dict,
+            )
+
+    with describe('Cannot launch without assignment name'):
+        do_launch(status=400, message=re.compile("'Display Name' option"))
+
+    with describe('With assignment name but not absolute service url'):
+        do_launch(
+            custom_component_display_name='My name',
+            lis_outcome_service_url='/studiohahaha',
+            status=400,
+            message=re.compile('launched CodeGrade from Studio'),
+        )
+
+    with describe('With assignment name and absolute service url'):
+        do_launch(
+            custom_component_display_name='My name',
+            lis_outcome_service_url='https://example.com/wow/url',
+            status=200,
+        )

--- a/psef_test/test_peer_feedback.py
+++ b/psef_test/test_peer_feedback.py
@@ -658,3 +658,40 @@ def test_peer_feedback_and_group_assignments(
         )
         test_client.req('delete', url, 204)
         enable_group(assig)
+
+
+@pytest.mark.parametrize('enable_after', [False, True])
+@pytest.mark.parametrize('student_amount', [4])
+def test_peer_feedback_and_test_student(
+    test_client, logged_in, describe, admin_user, session, tomorrow,
+    enable_after, student_amount
+):
+    with describe('setup'), logged_in(admin_user):
+        course = helpers.create_course(test_client)
+        assignment = helpers.create_assignment(
+            test_client, course, deadline=tomorrow
+        )
+        if not enable_after:
+            helpers.enable_peer_feedback(test_client, assignment)
+
+        users = [
+            helpers.get_id(
+                helpers.create_user_with_role(session, 'Student', course)
+            ) for _ in range(student_amount)
+        ]
+        helpers.create_submission(
+            test_client, assignment, is_test_submission=True
+        )
+        for user in users:
+            helpers.create_submission(test_client, assignment, for_user=user)
+
+        if enable_after:
+            helpers.enable_peer_feedback(test_client, assignment)
+
+    with describe('nobody should be connected to the test student'
+                  ), logged_in(admin_user):
+        conns = get_all_connections(assignment, 1)
+        assert len(conns) == student_amount
+        for user in users:
+            assert user in conns
+            assert all(conn in users for conn in users)

--- a/src/cg-math/index.js
+++ b/src/cg-math/index.js
@@ -25,7 +25,13 @@ export class CgMarkdownIt {
                 const inner = highlightCode(str.split('\n'), lang).join('<br>');
                 return `<pre class="code-block"><code>${inner}</code></pre>`;
             },
+            linkify: true,
         });
+        this.md.linkify
+            .set({ fuzzyLink: false })
+            .add('ftp:', null)
+            .add('//', null)
+            .add('mailto:', null);
 
         // Remember old renderer, if overridden, or proxy to default renderer
         const defaultRender =

--- a/src/components/GroupManagement.vue
+++ b/src/components/GroupManagement.vue
@@ -260,7 +260,9 @@ action is required.${divEnd}`;
             // setInterval is not used as this might cause a large load on the
             // server. Now we know there is `timeoutTime` between each request.
             const cont = data => {
-                this.memberStates = data;
+                if (data != null) {
+                    this.memberStates = data;
+                }
                 this.updateStates = null;
                 if (this.showLtiProgress && !this.compDestroyed) {
                     this.updateStates = setTimeout(() => this.reloadGroupStates(), timeoutTime);
@@ -269,7 +271,8 @@ action is required.${divEnd}`;
 
             this.group
                 .getMemberStates(this.assignment.id)
-                .then(({ data }) => cont(data), ({ data }) => cont(data));
+                // TODO: Show error when request failed.
+                .then(({ data }) => cont(data), () => cont());
         },
 
         startEditTitle() {

--- a/src/components/InnerIPythonViewer.vue
+++ b/src/components/InnerIPythonViewer.vue
@@ -190,7 +190,6 @@ export default {
 
     .code {
         padding-right: 0;
-        overflow-x: hidden;
     }
 
     .inner-markdown-viewer,

--- a/src/components/SnippetManager.vue
+++ b/src/components/SnippetManager.vue
@@ -3,10 +3,10 @@
 <loader :scale="2" class="" v-if="loading"/>
 <div class="snippet-manager" v-else>
     <b-form-group class="filter-group">
-        <input v-model="filter"
+        <input :value="filter"
+               v-debounce="newFilter => { filter = newFilter }"
                class="form-control"
-               placeholder="Type to Search"
-               v-on:keyup.enter="submit"/>
+               placeholder="Type to search snippets" />
     </b-form-group>
 
     <table class="table table-striped snippets-table">
@@ -149,7 +149,7 @@ export default {
         return {
             loading: true,
             snippets: [],
-            filter: '',
+            filter: this.$route.query.filterSnippets || '',
             editingSnippet: null,
             saveConfirmMessage: '',
         };
@@ -425,6 +425,16 @@ export default {
                     cmpNoCase(a.key, b.key),
                 );
             },
+        },
+
+        filter() {
+            const newQuery = Object.assign({}, this.$route.query);
+            newQuery.filterSnippets = this.filter || undefined;
+
+            this.$router.replace({
+                query: newQuery,
+                hash: this.$route.hash,
+            });
         },
     },
 

--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -45,6 +45,8 @@ const moodleProvider = makeLTI1p1Provider('Moodle');
 
 const sakaiProvider = makeLTI1p1Provider('Sakai');
 
+const openEdxProvider = makeLTI1p1Provider('Open edX');
+
 const canvasProvider = makeLTI1p1Provider('Canvas', {
     addBorder: true,
     supportsDeadline: true,
@@ -97,6 +99,7 @@ const LTI1p1Lookup: Record<string, LTIProvider> = mapToObject([
     canvasProvider,
     moodleProvider,
     sakaiProvider,
+    openEdxProvider,
 ], prov => [prov.tag || prov.lms, prov]);
 
 export function makeProvider(provider: LTIProviderServerData): LTIProvider {

--- a/src/lti_providers.ts
+++ b/src/lti_providers.ts
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
+import * as utils from '@/utils';
+
 // eslint-disable-next-line
 import type { LTIProviderServerData } from '@/api/v1/lti';
 
 import { AssertionError, mapToObject } from '@/utils/typed';
 
-const defaultLTIProvider = Object.freeze(<const>{
+const defaultLTI1p1Provider = Object.freeze(<const>{
+    lms: 'LMS',
     addBorder: false,
     supportsDeadline: false,
     supportsBonusPoints: false,
@@ -18,15 +21,25 @@ export type LTIProvider = {
     readonly supportsStateManagement: boolean;
 };
 
-function makeLTI1p1Provider(name: string, override: Omit<LTIProvider, 'lms'> | null = null): Readonly<LTIProvider> {
+type LTI1p1Provider = LTIProvider & { tag?: string };
+
+function makeLTI1p1Provider(
+    name: string,
+    override: Partial<Omit<LTI1p1Provider, 'lms'>> | null = null,
+): Readonly<LTI1p1Provider> {
     return Object.freeze(
-        Object.assign({}, defaultLTIProvider, override, { lms: name }),
+        Object.assign({}, defaultLTI1p1Provider, override, { lms: name }),
     );
 }
 
 const blackboardProvider = makeLTI1p1Provider('Blackboard');
 
-const brightSpaceProvider = makeLTI1p1Provider('Brightspace');
+const brightSpaceProvider = makeLTI1p1Provider('Brightspace', {
+    // In the backend we call Brightspace "BrightSpace" (with a capital S)
+    // so we need to override the tag that is used to identify the correct
+    // ltiProvider.
+    tag: 'BrightSpace',
+});
 
 const moodleProvider = makeLTI1p1Provider('Moodle');
 
@@ -84,12 +97,21 @@ const LTI1p1Lookup: Record<string, LTIProvider> = mapToObject([
     canvasProvider,
     moodleProvider,
     sakaiProvider,
-], prov => [prov.lms, prov]);
+], prov => [prov.tag || prov.lms, prov]);
 
 export function makeProvider(provider: LTIProviderServerData): LTIProvider {
     switch (provider.version) {
-        case 'lti1.1':
-            return LTI1p1Lookup[provider.lms];
+        case 'lti1.1': {
+            const prov = LTI1p1Lookup[provider.lms];
+            if (prov == null) {
+                utils.withSentry(Sentry => {
+                    Sentry.captureMessage(`Unknown LTI provider: ${provider.lms}`);
+                });
+                return defaultLTI1p1Provider;
+            } else {
+                return prov;
+            }
+        }
         case 'lti1.3':
             return new LTI1p3ProviderCapabilties(provider.lms, provider.capabilities);
         default:

--- a/src/pages/Submission.vue
+++ b/src/pages/Submission.vue
@@ -780,6 +780,10 @@ export default {
             storeLoadAutoTestResult: 'loadAutoTestResult',
         }),
 
+        ...mapActions('peer_feedback', {
+            storeLoadPeerFeedbackConnectionsForUser: 'loadConnectionsForUser',
+        }),
+
         loadData() {
             Promise.all([
                 this.storeLoadSingleAssignment({
@@ -793,6 +797,18 @@ export default {
                 }),
             ]).then(this.loadCurrentSubmissionData, error => {
                 this.error = error;
+            });
+        },
+
+        maybeLoadPeerFeedbackConnections() {
+            if (this.userId === this.$utils.getProps(this.submission, null, 'userId')) {
+                return Promise.resolve();
+            } else if (this.$utils.getProps(this.assignment, null, 'peer_feedback_settings') == null) {
+                return Promise.resolve();
+            }
+            return this.storeLoadPeerFeedbackConnectionsForUser({
+                userId: this.userId,
+                assignmentId: this.assignmentId,
             });
         },
 
@@ -853,6 +869,13 @@ export default {
                     assignmentId: this.assignmentId,
                     submissionId: this.submissionId,
                 }),
+                // We need to know if we are looking at a peer feedback subject
+                // of ours, because in that case we can probably give this
+                // student feedback.
+                //
+                // TODO: Don't do this load if it is not needed, e.g. if the
+                // current user is the teacher.
+                this.maybeLoadPeerFeedbackConnections(),
             ];
 
             // Load the AutoTest result of this submission. This must happen here because the

--- a/test/unit/specs/SnippetManager.spec.js
+++ b/test/unit/specs/SnippetManager.spec.js
@@ -1,15 +1,17 @@
 /* SPDX-License-Identifier: AGPL-3.0-only */
 import SnippetManager from '@/components/SnippetManager';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import VueRouter from 'vue-router';
+import VDebounce from 'vue-debounce';
 import Vuex from 'vuex';
 import BootstrapVue from 'bootstrap-vue'
+import router from '@/router';
 
 jest.mock('axios');
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
 localVue.use(BootstrapVue);
+localVue.use(VDebounce);
 
 const snippets = [
     { id: 1, key: 'key_abc', value: 'value_abc' },
@@ -82,6 +84,7 @@ describe('SnippetManager.vue', () => {
         });
 
         wrapper = shallowMount(SnippetManager, {
+            router,
             store,
             localVue,
             mocks: {


### PR DESCRIPTION
* Expand inline links in markdown viewers (#1448)
* Fix error when group member states cant be loaded (#1449)
* Fix double scrollbars in IPython viewer (#1450)
* Fix getting the Brightspace LTI provider in the frontend (#1451)
* Add support for Open edX (#1452)
* Remove Canvas advanced options section (#1453)
* Store snippets filter in the URL query params (#1454)
* Make sure test students are never used as peer feedback (#1455)
* Always load peer feedback connections on submission page (#1456) 
