### PR TITLE
Fix feedback in the FloatingFeedbackButton not being scrollable

### DIFF
--- a/cypress/integration/tests/file-viewer.spec.js
+++ b/cypress/integration/tests/file-viewer.spec.js
@@ -55,7 +55,7 @@ context('FileViewer', () => {
         cy.get('.feedback-reply.editing').should('not.exist');
     }
 
-    context.only('Floating feedback button', () => {
+    context('Floating feedback button', () => {
         it('should open a scrollable feedback area', () => {
             cy.wrap([
                 'venn1.png',

--- a/cypress/integration/tests/file-viewer.spec.js
+++ b/cypress/integration/tests/file-viewer.spec.js
@@ -113,6 +113,9 @@ context('FileViewer', () => {
                 // The feedback area should now be scrollable.
                 cy.get('.file-viewer .row.Pane:last-child')
                     .shouldBeScrollable('y');
+
+                cy.get('.file-viewer .submit-button[name="delete-feedback"]')
+                    .submit('success', { hasConfirm: true, waitForDefault: false });
             });
         });
     });

--- a/cypress/integration/tests/file-viewer.spec.js
+++ b/cypress/integration/tests/file-viewer.spec.js
@@ -55,6 +55,68 @@ context('FileViewer', () => {
         cy.get('.feedback-reply.editing').should('not.exist');
     }
 
+    context.only('Floating feedback button', () => {
+        it('should open a scrollable feedback area', () => {
+            cy.wrap([
+                'venn1.png',
+                'README.md',
+                'thomas-schaper',
+            ]).each(filename => {
+                openFile(filename);
+                cy.get('.file-viewer .feedback-button')
+                    .click({ force: true });
+
+                cy.get('.feedback-area-wrapper')
+                    .should('be.visible');
+
+                cy.get('.feedback-area-wrapper .save-button-wrapper .submit-button.btn-primary')
+                    .as('save-button');
+
+                // The save button should be visible right after opening the
+                // feedback area.
+                cy.get('@save-button')
+                    .should('be.visible');
+
+                // Resize the feedback area, making it smaller.  We need to
+                // drag to somewhere _within_ the .rs-panes because rs-panes
+                // listens to the mouseup event on the .rs-panes element. The
+                // `force` is needed because cypress complains that the resizer
+                // is blocked by another element, even though it isn't.
+                cy.get('.file-viewer .Resizer')
+                    .dragTo('@save-button', { force: true });
+
+                // The save button should not be visible anymore because the
+                // pane containing the feedback area has shrunk.
+                cy.get('@save-button')
+                    .should('not.be.visible');
+
+                // The pane containing the feedback area should be scrollable.
+                cy.get('.file-viewer .row.Pane:last-child')
+                    .shouldBeScrollable('y');
+
+                cy.get('.file-viewer .feedback-area-wrapper textarea')
+                    .setText('comment');
+                cy.get('@save-button')
+                    .submit('success', { waitForDefault: false });
+
+                // Wait for the feedback area to become non-editable.
+                cy.get('.file-viewer .add-reply')
+                    .should('be.visible');
+
+                // Resize the feedback area.
+                cy.get('.file-viewer .Resizer')
+                    .dragTo('.file-viewer .add-reply', { force: true });
+
+                cy.get('.file-viewer .add-reply')
+                    .should('not.be.visible');
+
+                // The feedback area should now be scrollable.
+                cy.get('.file-viewer .row.Pane:last-child')
+                    .shouldBeScrollable('y');
+            });
+        });
+    });
+
     context('Inline feedback preference', () => {
         function openSettings() {
             cy.get('.local-header .settings-toggle')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -699,18 +699,34 @@ Cypress.Commands.add('shouldReload', fn => {
     cy.window().should('not.have.property', 'beforeReload');
 });
 
-Cypress.Commands.add('dragTo', { prevSubject: 'optional' }, (subject, target, selector) => {
+Cypress.Commands.add('dragTo', { prevSubject: 'optional' }, (subject, target, selector, opts) => {
     if (subject) {
         subject = cy.wrap(subject);
+        opts = selector;
     } else {
         subject = cy.get(selector);
     }
 
     subject
-        .trigger('mousedown', { which: 1 })
+        .trigger('mousedown', Object.assign({}, opts, { which: 1 }));
     cy.get(target)
-        .trigger('mousemove')
-        .trigger('mouseup');
+        .trigger('mousemove', opts)
+        .trigger('mouseup', opts);
+});
+
+// Check if an element is scrollable. Pass 'x' as the first argument to check
+// only in the x-direction, or 'y' to only check in the y-direction. Pass
+// nothing to check both directions.
+Cypress.Commands.add('shouldBeScrollable', { prevSubject: true }, (subject, dir) => {
+    const { clientHeight, clientWidth, scrollHeight, scrollWidth } = subject.get(0);
+    const results = [];
+    if (dir == 'x' || dir == null) {
+        results.push(clientWidth < scrollWidth);
+    }
+    if (dir == 'y' || dir == null) {
+        results.push(clientHeight < scrollHeight);
+    }
+    expect(results).to.include(true);
 });
 
 //

--- a/src/components/FeedbackReply.vue
+++ b/src/components/FeedbackReply.vue
@@ -214,6 +214,7 @@
                         ref="deleteButton"
                         variant="secondary"
                         name="delete-feedback"
+                        container="window"
                         :submit="deleteFeedback"
                         confirm="Are you sure you want to delete this comment?"
                         invert-colors

--- a/src/components/FloatingFeedbackButton.vue
+++ b/src/components/FloatingFeedbackButton.vue
@@ -30,7 +30,7 @@
     </div>
 
     <div class="feedback-area-wrapper" v-if="showFeedback"
-             slot="secondPane">
+         slot="secondPane">
             <feedback-area
                 class="py-1"
                 @updated="updateSize"
@@ -312,5 +312,6 @@ export default {
 }
 .floating-feedback-button.pane-rs > .Pane.row {
     margin: 0;
+    overflow: auto;
 }
 </style>

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -150,8 +150,4 @@ export default {
     min-height: 5rem;
     text-align: center;
 }
-
-.image-viewer .Pane {
-    overflow: visible;
-}
 </style>

--- a/src/components/MarkdownViewer.vue
+++ b/src/components/MarkdownViewer.vue
@@ -116,9 +116,3 @@ export default {
     },
 };
 </script>
-
-<style lang="less">
-.markdown-viewer .Pane {
-    overflow: visible;
-}
-</style>

--- a/src/components/PdfViewer.vue
+++ b/src/components/PdfViewer.vue
@@ -211,8 +211,4 @@ object {
 .pdf-viewer.floating-feedback-button .feedback-area-wrapper {
     flex: unset;
 }
-
-.pdf-viewer .Pane {
-    overflow: visible;
-}
 </style>


### PR DESCRIPTION
The feedback was not scrollable because the `.Pane`s in the components using the `FloatingFeedbackButton` all had `overflow: visible` instead of `auto`.