### PR TITLE
Add checkerboard background to image viewer

### DIFF
--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -152,7 +152,7 @@ export default {
 
     /* Checkerboard pattern. */
     background-size: 1rem;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyIDIi PjxyZWN0IGZpbGw9IiNmNGY0ZjQiIHg9IjAiIHk9IjAiIHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz48 cmVjdCBmaWxsPSIjZjRmNGY0IiB4PSIxIiB5PSIxIiB3aWR0aD0iMSIgaGVpZ2h0PSIxIi8+PC9z dmc+Cg==');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2 2"><rect fill="rgba(0, 0, 0, 0.0625)" x="0" y="0" width="1" height="1"/><rect fill="rgba(0, 0, 0, 0.0625)" x="1" y="1" width="1" height="1"/></svg>');
 }
 
 .image-viewer .Pane {

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -149,6 +149,10 @@ export default {
     display: block;
     min-height: 5rem;
     text-align: center;
+
+    /* Checkerboard pattern. */
+    background-size: 1rem;
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyIDIi PjxyZWN0IGZpbGw9IiNmNGY0ZjQiIHg9IjAiIHk9IjAiIHdpZHRoPSIxIiBoZWlnaHQ9IjEiLz48 cmVjdCBmaWxsPSIjZjRmNGY0IiB4PSIxIiB5PSIxIiB3aWR0aD0iMSIgaGVpZ2h0PSIxIi8+PC9z dmc+Cg==');
 }
 
 .image-viewer .Pane {


### PR DESCRIPTION
Adds a checkerboard background pattern to the image viewer:

![checker](https://user-images.githubusercontent.com/3612514/95459895-82c90300-0974-11eb-86e4-6a0befa4190a.png)

I first tried to do it with a CSS gradient, but that was very glitchy at different zoom levels, because it was rendering half squares and stitching them together. So this uses a very simple svg containing only 2 rects to achieve a better result.