### PR TITLE
Fix the CodeViewer when loading settings fails

### DIFF
--- a/src/components/CodeViewer.vue
+++ b/src/components/CodeViewer.vue
@@ -186,12 +186,14 @@ export default {
         loadSettings() {
             this.selectedLanguage = null;
             return this.$hlanguageStore.getItem(this.fileId).then(lang => {
-                if (lang !== null) {
+                if (lang != null) {
                     this.$emit('language', lang);
                     this.selectedLanguage = lang;
                 } else {
                     this.selectedLanguage = 'Default';
                 }
+            }, () => {
+                this.selectedLanguage = 'Default';
             });
         },
 


### PR DESCRIPTION
In Google Chrome in incognito mode the language store would return `undefined`
when getting the language, which we would then store in `selectedLanguage`,
but in the rest of the component we check with `this.selectedLanguage != null`
to make sure we already loaded the language, and of course `null ==
undefined`. This PR fixes that behavior by also checking the return from
`getItem` against `null` with eqeq and not eqeqeq. Furthermore, this also adds
a catch clause on the call to `getItem` to make sure we never crash/freeze the
page because of that function rejecting.